### PR TITLE
Add support for asciidoc(tor) formatted blogs, including styling for admonitions

### DIFF
--- a/_blog-src/_config.yml
+++ b/_blog-src/_config.yml
@@ -2,7 +2,7 @@
 title: apiman blog
 email: apiman-user@lists.jboss.org
 description: > # this means to ignore newlines until "baseurl:"
-  The apiman project brings an open source development methodology to 
+  The apiman project brings an open source development methodology to
   API Management, coupling a rich API design & configuration layer with
   a blazingly fast runtime.  This is the official apiman blog, where
   we discuss....whatever we're thinking about!
@@ -14,5 +14,27 @@ github_username: apiman
 # Build settings
 markdown: kramdown
 
+# kramdown:
+#   input: GFM
+
 destination: ../blog
 excerpt_separator: <!--more-->
+
+gems:
+  - jekyll-asciidoc
+  - asciidoctor-diagram
+
+asciidoc: asciidoctor
+asciidoc_ext: asciidoc,adoc,ad
+asciidoctor:
+  attributes:
+    - imagesdir=/blog/images/generated
+    - imagesoutdir=/images/generated
+    - icons=font
+    - source-highlighter=coderay
+    - idprefix=
+    - idseparator=-
+    - linkattrs
+
+sass:
+  sass_dir: _sass

--- a/_blog-src/_config.yml
+++ b/_blog-src/_config.yml
@@ -10,6 +10,7 @@ baseurl: "/blog"
 url: "http://apiman.io" # the base hostname & protocol for your site
 twitter_username: apiman_io
 github_username: apiman
+timezone: America/New_York
 
 # Build settings
 markdown: kramdown

--- a/_blog-src/_includes/head.html
+++ b/_blog-src/_includes/head.html
@@ -11,7 +11,11 @@
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.css?v=1.1.3.Final" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.responsive.css?v=1.1.3.Final" rel="stylesheet">
+  <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
   <link href="/blog/css/highlight.css" rel="stylesheet">
+  <link href="/blog/css/main.css" rel="stylesheet">
+  <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
+  
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>

--- a/_blog-src/_sass/_layout.scss
+++ b/_blog-src/_sass/_layout.scss
@@ -1,236 +1,140 @@
+$section-divider-colour: #efefed;
+
+$admonition-content-color: #777;
+$admonition-note-color: green;
+$admonition-warning-color: #bb5f18;
+$admonition-caution-color: #bf0000;
+$admonition-important-color: #243446;
+
+
 /**
- * Site header
+ * Thanks, asciidoctor!
  */
-.site-header {
-    border-top: 5px solid $grey-color-dark;
-    border-bottom: 1px solid $grey-color-light;
-    min-height: 56px;
-
-    // Positioning context for the mobile navigation icon
-    position: relative;
+// Asciidoctor's admonition stuff
+.admonitionblock > table {
+    border-collapse: separate;
+    border: 0;
+    background: none;
+    width: 100%;
+    margin-top: 1.8em;
+    margin-bottom: 1.8em;
 }
-
-.site-title {
-    font-size: 26px;
-    line-height: 56px;
-    letter-spacing: -1px;
+.admonitionblock > table td.icon {
+    text-align: center;
+    width: 80px;
+}
+.admonitionblock > table td.icon img {
+    max-width: none;
+}
+.admonitionblock > table td.icon .title {
+    font-weight: bold;
+    text-transform: uppercase;
+}
+.admonitionblock > table td.content {
+    padding-left: 1.125em;
+    padding-right: 1.5em;
+    border-left: 1px solid $section-divider-colour;
+    color: $admonition-content-color;
+}
+.admonitionblock > table td.content >:last-child >:last-child {
     margin-bottom: 0;
-    float: left;
+}
 
-    &,
-    &:visited {
-        color: $grey-color-dark;
+td.content {
+    padding-left: 1.125em;
+    padding-right: 1.5em;
+
+    & > :last-child > :last-child {
+      margin-bottom: 0;
     }
 }
 
-.site-nav {
-    float: right;
-    line-height: 56px;
-
-    .menu-icon {
-        display: none;
-    }
-
-    .page-link {
-        color: $text-color;
-        line-height: $base-line-height;
-
-        // Gaps between nav items, but not on the first one
-        &:not(:first-child) {
-            margin-left: 20px;
-        }
-    }
-
-    @include media-query($on-palm) {
-        position: absolute;
-        top: 9px;
-        right: 30px;
-        background-color: $background-color;
-        border: 1px solid $grey-color-light;
-        border-radius: 5px;
-        text-align: right;
-
-        .menu-icon {
-            display: block;
-            float: right;
-            width: 36px;
-            height: 26px;
-            line-height: 0;
-            padding-top: 10px;
-            text-align: center;
-
-            > svg {
-                width: 18px;
-                height: 15px;
-
-                path {
-                    fill: $grey-color-dark;
-                }
-            }
-        }
-
-        .trigger {
-            clear: both;
-            display: none;
-        }
-
-        &:hover .trigger {
-            display: block;
-            padding-bottom: 5px;
-        }
-
-        .page-link {
-            display: block;
-            padding: 5px 10px;
-        }
-    }
+// Asciidoctor font-awesome stuff
+span.icon > .fa {
+  cursor: default;
 }
 
+.admonitionblock td.icon {
+  [class^="fa icon-"] {
+    font-size: 2.5em;
+    text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
+    cursor: default;
+  }
 
+  .icon-note:before {
+    content: "\f05a";
+    //color: scale-color($primary-color, $lightness: $rainbow-lightness);
+    color: $admonition-note-color;
+  }
 
-/**
- * Site footer
- */
-.site-footer {
-    border-top: 1px solid $grey-color-light;
-    padding: $spacing-unit 0;
+  .icon-tip:before {
+    content: "\f0eb";
+    text-shadow: 1px 1px 2px rgba(155, 155, 0, .8);
+    color: #111;
+  }
+
+  .icon-warning:before {
+    content: "\f071";
+    //color: scale-color(darkorange, $lightness: $rainbow-lightness);
+    color: $admonition-warning-color;
+  }
+
+  .icon-caution:before {
+    content: "\f06d";
+    //color: scale-color(orangered, $lightness: $rainbow-lightness);
+    color: $admonition-caution-color;
+  }
+
+  .icon-important:before {
+    content: "\f06a";
+    //color: scale-color(red, $lightness: $rainbow-lightness);
+    color: $admonition-important-color;
+  }
 }
 
-.footer-heading {
-    font-size: 18px;
-    margin-bottom: $spacing-unit / 2;
+.conum[data-value] {
+  display: inline-block;
+  color: #fff !important;
+  //background-color: $body-font-color;
+  //@include radius(100px);
+  text-align: center;
+  font-size: 0.75em;
+  width: 1.67em;
+  height: 1.67em;
+  line-height: 1.67em;
+  font-style: normal;
+  font-weight: bold;
+
+  & * {
+    color: #fff !important;
+  }
+
+  & + b {
+    display: none;
+  }
+
+  &:after {
+    content: attr(data-value);
+  }
+
+  pre & {
+    position: relative;
+    top: -0.125em;
+  }
 }
 
-.contact-list,
-.social-media-list {
-    list-style: none;
-    margin-left: 0;
+// hack to disallow syntax highlighting from changing the color
+b.conum * {
+  color: inherit !important;
 }
 
-.footer-col-wrapper {
-    font-size: 15px;
-    color: $grey-color;
-    margin-left: -$spacing-unit / 2;
-    @extend %clearfix;
+// hack for when highlight.js adds a bogus element into DOM
+// QUESTION should we solve this w/ javascript instead?
+.conum:not([data-value]):empty {
+  display: none;
 }
 
-.footer-col {
-    float: left;
-    margin-bottom: $spacing-unit / 2;
-    padding-left: $spacing-unit / 2;
-}
-
-.footer-col-1 {
-    width: -webkit-calc(35% - (#{$spacing-unit} / 2));
-    width:         calc(35% - (#{$spacing-unit} / 2));
-}
-
-.footer-col-2 {
-    width: -webkit-calc(20% - (#{$spacing-unit} / 2));
-    width:         calc(20% - (#{$spacing-unit} / 2));
-}
-
-.footer-col-3 {
-    width: -webkit-calc(45% - (#{$spacing-unit} / 2));
-    width:         calc(45% - (#{$spacing-unit} / 2));
-}
-
-@include media-query($on-laptop) {
-    .footer-col-1,
-    .footer-col-2 {
-        width: -webkit-calc(50% - (#{$spacing-unit} / 2));
-        width:         calc(50% - (#{$spacing-unit} / 2));
-    }
-
-    .footer-col-3 {
-        width: -webkit-calc(100% - (#{$spacing-unit} / 2));
-        width:         calc(100% - (#{$spacing-unit} / 2));
-    }
-}
-
-@include media-query($on-palm) {
-    .footer-col {
-        float: none;
-        width: -webkit-calc(100% - (#{$spacing-unit} / 2));
-        width:         calc(100% - (#{$spacing-unit} / 2));
-    }
-}
-
-
-
-/**
- * Page content
- */
-.page-content {
-    padding: $spacing-unit 0;
-}
-
-.page-heading {
-    font-size: 20px;
-}
-
-.post-list {
-    margin-left: 0;
-    list-style: none;
-
-    > li {
-        margin-bottom: $spacing-unit;
-    }
-}
-
-.post-meta {
-    font-size: $small-font-size;
-    color: $grey-color;
-}
-
-.post-link {
-    display: block;
-    font-size: 24px;
-}
-
-
-
-/**
- * Posts
- */
-.post-header {
-    margin-bottom: $spacing-unit;
-}
-
-.post-title {
-    font-size: 42px;
-    letter-spacing: -1px;
-    line-height: 1;
-
-    @include media-query($on-laptop) {
-        font-size: 36px;
-    }
-}
-
-.post-content {
-    margin-bottom: $spacing-unit;
-
-    h2 {
-        font-size: 32px;
-
-        @include media-query($on-laptop) {
-            font-size: 28px;
-        }
-    }
-
-    h3 {
-        font-size: 26px;
-
-        @include media-query($on-laptop) {
-            font-size: 22px;
-        }
-    }
-
-    h4 {
-        font-size: 20px;
-
-        @include media-query($on-laptop) {
-            font-size: 18px;
-        }
-    }
+// Dividers between sections
+.sect1+.sect1 {
+    border-top: 1px solid $section-divider-colour;
 }

--- a/_blog-src/css/coderay-asciidoctor.css
+++ b/_blog-src/css/coderay-asciidoctor.css
@@ -1,0 +1,89 @@
+/* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
+/*pre.CodeRay {background-color:#f7f7f8;}*/
+.CodeRay .line-numbers{border-right:1px solid #d8d8d8;padding:0 0.5em 0 .25em}
+.CodeRay span.line-numbers{display:inline-block;margin-right:.5em;color:rgba(0,0,0,.3)}
+.CodeRay .line-numbers strong{font-weight: normal}
+table.CodeRay{border-collapse:separate;border-spacing:0;margin-bottom:0;border:0;background:none}
+table.CodeRay td{vertical-align: top}
+table.CodeRay td.line-numbers{text-align:right}
+table.CodeRay td.line-numbers>pre{padding:0;color:rgba(0,0,0,.3)}
+table.CodeRay td.code{padding:0 0 0 .5em}
+table.CodeRay td.code>pre{padding:0}
+.CodeRay .debug{color:#fff !important;background:#000080 !important}
+.CodeRay .annotation{color:#007}
+.CodeRay .attribute-name{color:#000080}
+.CodeRay .attribute-value{color:#700}
+.CodeRay .binary{color:#509}
+.CodeRay .comment{color:#998;font-style:italic}
+.CodeRay .char{color:#04d}
+.CodeRay .char .content{color:#04d}
+.CodeRay .char .delimiter{color:#039}
+.CodeRay .class{color:#458;font-weight:bold}
+.CodeRay .complex{color:#a08}
+.CodeRay .constant,.CodeRay .predefined-constant{color:#008080}
+.CodeRay .color{color:#099}
+.CodeRay .class-variable{color:#369}
+.CodeRay .decorator{color:#b0b}
+.CodeRay .definition{color:#099}
+.CodeRay .delimiter{color:#000}
+.CodeRay .doc{color:#970}
+.CodeRay .doctype{color:#34b}
+.CodeRay .doc-string{color:#d42}
+.CodeRay .escape{color:#666}
+.CodeRay .entity{color:#800}
+.CodeRay .error{color:#808}
+.CodeRay .exception{color:inherit}
+.CodeRay .filename{color:#099}
+.CodeRay .function{color:#900;font-weight:bold}
+.CodeRay .global-variable{color:#008080}
+.CodeRay .hex{color:#058}
+.CodeRay .integer,.CodeRay .float{color:#099}
+.CodeRay .include{color:#555}
+.CodeRay .inline{color:#00}
+.CodeRay .inline .inline{background:#ccc}
+.CodeRay .inline .inline .inline{background:#bbb}
+.CodeRay .inline .inline-delimiter{color:#d14}
+.CodeRay .inline-delimiter{color:#d14}
+.CodeRay .important{color:#555;font-weight:bold}
+.CodeRay .interpreted{color:#b2b}
+.CodeRay .instance-variable{color:#008080}
+.CodeRay .label{color:#970}
+.CodeRay .local-variable{color:#963}
+.CodeRay .octal{color:#40e}
+.CodeRay .predefined{color:#369}
+.CodeRay .preprocessor{color:#579}
+.CodeRay .pseudo-class{color:#555}
+.CodeRay .directive{font-weight:bold}
+.CodeRay .type{font-weight:bold}
+.CodeRay .predefined-type{color:inherit}
+.CodeRay .reserved,.CodeRay .keyword {color:#000;font-weight:bold}
+.CodeRay .key{color:#808}
+.CodeRay .key .delimiter{color:#606}
+.CodeRay .key .char{color:#80f}
+.CodeRay .value{color:#088}
+.CodeRay .regexp .delimiter{color:#808}
+.CodeRay .regexp .content{color:#808}
+.CodeRay .regexp .modifier{color:#808}
+.CodeRay .regexp .char{color:#d14}
+.CodeRay .regexp .function{color:#404;font-weight:bold}
+.CodeRay .string{color:#d20}
+.CodeRay .string .string .string{background:#ffd0d0}
+.CodeRay .string .content{color:#d14}
+.CodeRay .string .char{color:#d14}
+.CodeRay .string .delimiter{color:#d14}
+.CodeRay .shell{color:#d14}
+.CodeRay .shell .delimiter{color:#d14}
+.CodeRay .symbol{color:#990073}
+.CodeRay .symbol .content{color:#a60}
+.CodeRay .symbol .delimiter{color:#630}
+.CodeRay .tag{color:#008080}
+.CodeRay .tag-special{color:#d70}
+.CodeRay .variable{color:#036}
+.CodeRay .insert{background:#afa}
+.CodeRay .delete{background:#faa}
+.CodeRay .change{color:#aaf;background:#007}
+.CodeRay .head{color:#f8f;background:#505}
+.CodeRay .insert .insert{color:#080}
+.CodeRay .delete .delete{color:#800}
+.CodeRay .change .change{color:#66f}
+.CodeRay .head .head{color:#f4f}

--- a/_blog-src/css/main.scss
+++ b/_blog-src/css/main.scss
@@ -44,7 +44,7 @@ $on-laptop:        800px;
 
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import
-        "base",
-        "layout",
-        "syntax-highlighting"
+//        "base",
+        "layout"
+//        "syntax-highlighting"
 ;

--- a/blog/about/index.html
+++ b/blog/about/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" href="http://www.apiman.io/latest/resources/images/favicon.ico">
   <title>About</title>
-  <meta name="description" content="The apiman project brings an open source development methodology to  API Management, coupling a rich API design & configuration layer with a blazingly fast runtime.  This is the official apiman blog, where we discuss....whatever we're thinking about!
+  <meta name="description" content="The apiman project brings an open source development methodology to API Management, coupling a rich API design & configuration layer with a blazingly fast runtime.  This is the official apiman blog, where we discuss....whatever we're thinking about!
 ">
 
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
@@ -14,7 +14,11 @@
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.css?v=1.1.3.Final" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.responsive.css?v=1.1.3.Final" rel="stylesheet">
+  <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
   <link href="/blog/css/highlight.css" rel="stylesheet">
+  <link href="/blog/css/main.css" rel="stylesheet">
+  <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
+  
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>

--- a/blog/api-manager/swagger/service/ui/2015/06/02/swagger.html
+++ b/blog/api-manager/swagger/service/ui/2015/06/02/swagger.html
@@ -13,7 +13,11 @@
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.css?v=1.1.3.Final" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.responsive.css?v=1.1.3.Final" rel="stylesheet">
+  <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
   <link href="/blog/css/highlight.css" rel="stylesheet">
+  <link href="/blog/css/main.css" rel="stylesheet">
+  <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
+  
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>

--- a/blog/authorization/authentication/policy/2015/05/08/authorization.html
+++ b/blog/authorization/authentication/policy/2015/05/08/authorization.html
@@ -13,7 +13,11 @@
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.css?v=1.1.3.Final" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.responsive.css?v=1.1.3.Final" rel="stylesheet">
+  <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
   <link href="/blog/css/highlight.css" rel="stylesheet">
+  <link href="/blog/css/main.css" rel="stylesheet">
+  <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
+  
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>

--- a/blog/css/main.css
+++ b/blog/css/main.css
@@ -1,449 +1,89 @@
 /**
- * Reset some basic elements
+ * Thanks, asciidoctor!
  */
-body, h1, h2, h3, h4, h5, h6,
-p, blockquote, pre, hr,
-dl, dd, ol, ul, figure {
-  margin: 0;
-  padding: 0; }
+.admonitionblock > table {
+  border-collapse: separate;
+  border: 0;
+  background: none;
+  width: 100%;
+  margin-top: 1.8em;
+  margin-bottom: 1.8em; }
 
-/**
- * Basic styling
- */
-body {
-  font-family: Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 300;
-  color: #111;
-  background-color: #fdfdfd;
-  -webkit-text-size-adjust: 100%; }
+.admonitionblock > table td.icon {
+  text-align: center;
+  width: 80px; }
 
-/**
- * Set `margin-bottom` to maintain vertical rhythm
- */
-h1, h2, h3, h4, h5, h6,
-p, blockquote, pre,
-ul, ol, dl, figure,
-.highlight {
-  margin-bottom: 15px; }
+.admonitionblock > table td.icon img {
+  max-width: none; }
 
-/**
- * Images
- */
-img {
-  max-width: 100%;
-  vertical-align: middle; }
+.admonitionblock > table td.icon .title {
+  font-weight: bold;
+  text-transform: uppercase; }
 
-/**
- * Figures
- */
-figure > img {
-  display: block; }
+.admonitionblock > table td.content {
+  padding-left: 1.125em;
+  padding-right: 1.5em;
+  border-left: 1px solid #efefed;
+  color: #777; }
 
-figcaption {
-  font-size: 14px; }
-
-/**
- * Lists
- */
-ul, ol {
-  margin-left: 30px; }
-
-li > ul,
-li > ol {
+.admonitionblock > table td.content > :last-child > :last-child {
   margin-bottom: 0; }
 
-/**
- * Headings
- */
-h1, h2, h3, h4, h5, h6 {
-  font-weight: 300; }
-
-/**
- * Links
- */
-a {
-  color: #2a7ae2;
-  text-decoration: none; }
-  a:visited {
-    color: #1756a9; }
-  a:hover {
-    color: #111;
-    text-decoration: underline; }
-
-/**
- * Blockquotes
- */
-blockquote {
-  color: #828282;
-  border-left: 4px solid #e8e8e8;
-  padding-left: 15px;
-  font-size: 18px;
-  letter-spacing: -1px;
-  font-style: italic; }
-  blockquote > :last-child {
+td.content {
+  padding-left: 1.125em;
+  padding-right: 1.5em; }
+  td.content > :last-child > :last-child {
     margin-bottom: 0; }
 
-/**
- * Code formatting
- */
-pre,
-code {
-  font-size: 15px;
-  border: 1px solid #e8e8e8;
-  border-radius: 3px;
-  background-color: #eef; }
+span.icon > .fa {
+  cursor: default; }
 
-code {
-  padding: 1px 5px; }
+.admonitionblock td.icon [class^="fa icon-"] {
+  font-size: 2.5em;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+  cursor: default; }
+.admonitionblock td.icon .icon-note:before {
+  content: "\f05a";
+  color: green; }
+.admonitionblock td.icon .icon-tip:before {
+  content: "\f0eb";
+  text-shadow: 1px 1px 2px rgba(155, 155, 0, 0.8);
+  color: #111; }
+.admonitionblock td.icon .icon-warning:before {
+  content: "\f071";
+  color: #bb5f18; }
+.admonitionblock td.icon .icon-caution:before {
+  content: "\f06d";
+  color: #bf0000; }
+.admonitionblock td.icon .icon-important:before {
+  content: "\f06a";
+  color: #243446; }
 
-pre {
-  padding: 8px 12px;
-  overflow-x: scroll; }
-  pre > code {
-    border: 0;
-    padding-right: 0;
-    padding-left: 0; }
-
-/**
- * Wrapper
- */
-.wrapper {
-  max-width: -webkit-calc(800px - (30px * 2));
-  max-width: calc(800px - (30px * 2));
-  margin-right: auto;
-  margin-left: auto;
-  padding-right: 30px;
-  padding-left: 30px; }
-  @media screen and (max-width: 800px) {
-    .wrapper {
-      max-width: -webkit-calc(800px - (30px));
-      max-width: calc(800px - (30px));
-      padding-right: 15px;
-      padding-left: 15px; } }
-
-/**
- * Clearfix
- */
-.wrapper:after, .footer-col-wrapper:after {
-  content: "";
-  display: table;
-  clear: both; }
-
-/**
- * Icons
- */
-.icon > svg {
+.conum[data-value] {
   display: inline-block;
-  width: 16px;
-  height: 16px;
-  vertical-align: middle; }
-  .icon > svg path {
-    fill: #828282; }
-
-/**
- * Site header
- */
-.site-header {
-  border-top: 5px solid #424242;
-  border-bottom: 1px solid #e8e8e8;
-  min-height: 56px;
-  position: relative; }
-
-.site-title {
-  font-size: 26px;
-  line-height: 56px;
-  letter-spacing: -1px;
-  margin-bottom: 0;
-  float: left; }
-  .site-title, .site-title:visited {
-    color: #424242; }
-
-.site-nav {
-  float: right;
-  line-height: 56px; }
-  .site-nav .menu-icon {
+  color: #fff !important;
+  text-align: center;
+  font-size: 0.75em;
+  width: 1.67em;
+  height: 1.67em;
+  line-height: 1.67em;
+  font-style: normal;
+  font-weight: bold; }
+  .conum[data-value] * {
+    color: #fff !important; }
+  .conum[data-value] + b {
     display: none; }
-  .site-nav .page-link {
-    color: #111;
-    line-height: 1.5; }
-    .site-nav .page-link:not(:first-child) {
-      margin-left: 20px; }
-  @media screen and (max-width: 600px) {
-    .site-nav {
-      position: absolute;
-      top: 9px;
-      right: 30px;
-      background-color: #fdfdfd;
-      border: 1px solid #e8e8e8;
-      border-radius: 5px;
-      text-align: right; }
-      .site-nav .menu-icon {
-        display: block;
-        float: right;
-        width: 36px;
-        height: 26px;
-        line-height: 0;
-        padding-top: 10px;
-        text-align: center; }
-        .site-nav .menu-icon > svg {
-          width: 18px;
-          height: 15px; }
-          .site-nav .menu-icon > svg path {
-            fill: #424242; }
-      .site-nav .trigger {
-        clear: both;
-        display: none; }
-      .site-nav:hover .trigger {
-        display: block;
-        padding-bottom: 5px; }
-      .site-nav .page-link {
-        display: block;
-        padding: 5px 10px; } }
+  .conum[data-value]:after {
+    content: attr(data-value); }
+  pre .conum[data-value] {
+    position: relative;
+    top: -0.125em; }
 
-/**
- * Site footer
- */
-.site-footer {
-  border-top: 1px solid #e8e8e8;
-  padding: 30px 0; }
+b.conum * {
+  color: inherit !important; }
 
-.footer-heading {
-  font-size: 18px;
-  margin-bottom: 15px; }
+.conum:not([data-value]):empty {
+  display: none; }
 
-.contact-list,
-.social-media-list {
-  list-style: none;
-  margin-left: 0; }
-
-.footer-col-wrapper {
-  font-size: 15px;
-  color: #828282;
-  margin-left: -15px; }
-
-.footer-col {
-  float: left;
-  margin-bottom: 15px;
-  padding-left: 15px; }
-
-.footer-col-1 {
-  width: -webkit-calc(35% - (30px / 2));
-  width: calc(35% - (30px / 2)); }
-
-.footer-col-2 {
-  width: -webkit-calc(20% - (30px / 2));
-  width: calc(20% - (30px / 2)); }
-
-.footer-col-3 {
-  width: -webkit-calc(45% - (30px / 2));
-  width: calc(45% - (30px / 2)); }
-
-@media screen and (max-width: 800px) {
-  .footer-col-1,
-  .footer-col-2 {
-    width: -webkit-calc(50% - (30px / 2));
-    width: calc(50% - (30px / 2)); }
-
-  .footer-col-3 {
-    width: -webkit-calc(100% - (30px / 2));
-    width: calc(100% - (30px / 2)); } }
-@media screen and (max-width: 600px) {
-  .footer-col {
-    float: none;
-    width: -webkit-calc(100% - (30px / 2));
-    width: calc(100% - (30px / 2)); } }
-/**
- * Page content
- */
-.page-content {
-  padding: 30px 0; }
-
-.page-heading {
-  font-size: 20px; }
-
-.post-list {
-  margin-left: 0;
-  list-style: none; }
-  .post-list > li {
-    margin-bottom: 30px; }
-
-.post-meta {
-  font-size: 14px;
-  color: #828282; }
-
-.post-link {
-  display: block;
-  font-size: 24px; }
-
-/**
- * Posts
- */
-.post-header {
-  margin-bottom: 30px; }
-
-.post-title {
-  font-size: 42px;
-  letter-spacing: -1px;
-  line-height: 1; }
-  @media screen and (max-width: 800px) {
-    .post-title {
-      font-size: 36px; } }
-
-.post-content {
-  margin-bottom: 30px; }
-  .post-content h2 {
-    font-size: 32px; }
-    @media screen and (max-width: 800px) {
-      .post-content h2 {
-        font-size: 28px; } }
-  .post-content h3 {
-    font-size: 26px; }
-    @media screen and (max-width: 800px) {
-      .post-content h3 {
-        font-size: 22px; } }
-  .post-content h4 {
-    font-size: 20px; }
-    @media screen and (max-width: 800px) {
-      .post-content h4 {
-        font-size: 18px; } }
-
-/**
- * Syntax highlighting styles
- */
-.highlight {
-  background: #fff; }
-  .highlight .c {
-    color: #998;
-    font-style: italic; }
-  .highlight .err {
-    color: #a61717;
-    background-color: #e3d2d2; }
-  .highlight .k {
-    font-weight: bold; }
-  .highlight .o {
-    font-weight: bold; }
-  .highlight .cm {
-    color: #998;
-    font-style: italic; }
-  .highlight .cp {
-    color: #999;
-    font-weight: bold; }
-  .highlight .c1 {
-    color: #998;
-    font-style: italic; }
-  .highlight .cs {
-    color: #999;
-    font-weight: bold;
-    font-style: italic; }
-  .highlight .gd {
-    color: #000;
-    background-color: #fdd; }
-  .highlight .gd .x {
-    color: #000;
-    background-color: #faa; }
-  .highlight .ge {
-    font-style: italic; }
-  .highlight .gr {
-    color: #a00; }
-  .highlight .gh {
-    color: #999; }
-  .highlight .gi {
-    color: #000;
-    background-color: #dfd; }
-  .highlight .gi .x {
-    color: #000;
-    background-color: #afa; }
-  .highlight .go {
-    color: #888; }
-  .highlight .gp {
-    color: #555; }
-  .highlight .gs {
-    font-weight: bold; }
-  .highlight .gu {
-    color: #aaa; }
-  .highlight .gt {
-    color: #a00; }
-  .highlight .kc {
-    font-weight: bold; }
-  .highlight .kd {
-    font-weight: bold; }
-  .highlight .kp {
-    font-weight: bold; }
-  .highlight .kr {
-    font-weight: bold; }
-  .highlight .kt {
-    color: #458;
-    font-weight: bold; }
-  .highlight .m {
-    color: #099; }
-  .highlight .s {
-    color: #d14; }
-  .highlight .na {
-    color: #008080; }
-  .highlight .nb {
-    color: #0086B3; }
-  .highlight .nc {
-    color: #458;
-    font-weight: bold; }
-  .highlight .no {
-    color: #008080; }
-  .highlight .ni {
-    color: #800080; }
-  .highlight .ne {
-    color: #900;
-    font-weight: bold; }
-  .highlight .nf {
-    color: #900;
-    font-weight: bold; }
-  .highlight .nn {
-    color: #555; }
-  .highlight .nt {
-    color: #000080; }
-  .highlight .nv {
-    color: #008080; }
-  .highlight .ow {
-    font-weight: bold; }
-  .highlight .w {
-    color: #bbb; }
-  .highlight .mf {
-    color: #099; }
-  .highlight .mh {
-    color: #099; }
-  .highlight .mi {
-    color: #099; }
-  .highlight .mo {
-    color: #099; }
-  .highlight .sb {
-    color: #d14; }
-  .highlight .sc {
-    color: #d14; }
-  .highlight .sd {
-    color: #d14; }
-  .highlight .s2 {
-    color: #d14; }
-  .highlight .se {
-    color: #d14; }
-  .highlight .sh {
-    color: #d14; }
-  .highlight .si {
-    color: #d14; }
-  .highlight .sx {
-    color: #d14; }
-  .highlight .sr {
-    color: #009926; }
-  .highlight .s1 {
-    color: #d14; }
-  .highlight .ss {
-    color: #990073; }
-  .highlight .bp {
-    color: #999; }
-  .highlight .vc {
-    color: #008080; }
-  .highlight .vg {
-    color: #008080; }
-  .highlight .vi {
-    color: #008080; }
-  .highlight .il {
-    color: #099; }
+.sect1 + .sect1 {
+  border-top: 1px solid #efefed; }

--- a/blog/eclipse/development/maven/2015/06/04/dev-environment.html
+++ b/blog/eclipse/development/maven/2015/06/04/dev-environment.html
@@ -13,7 +13,11 @@
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.css?v=1.1.3.Final" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.responsive.css?v=1.1.3.Final" rel="stylesheet">
+  <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
   <link href="/blog/css/highlight.css" rel="stylesheet">
+  <link href="/blog/css/main.css" rel="stylesheet">
+  <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
+  
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>

--- a/blog/feed.xml
+++ b/blog/feed.xml
@@ -2,12 +2,12 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>apiman blog</title>
-    <description>The apiman project brings an open source development methodology to  API Management, coupling a rich API design &amp; configuration layer with a blazingly fast runtime.  This is the official apiman blog, where we discuss....whatever we&#39;re thinking about!
+    <description>The apiman project brings an open source development methodology to API Management, coupling a rich API design &amp; configuration layer with a blazingly fast runtime.  This is the official apiman blog, where we discuss....whatever we&#39;re thinking about!
 </description>
     <link>http://apiman.io/blog/</link>
     <atom:link href="http://apiman.io/blog/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Fri, 05 Jun 2015 11:00:21 -0400</pubDate>
-    <lastBuildDate>Fri, 05 Jun 2015 11:00:21 -0400</lastBuildDate>
+    <pubDate>Mon, 08 Jun 2015 08:37:49 -0400</pubDate>
+    <lastBuildDate>Mon, 08 Jun 2015 08:37:49 -0400</lastBuildDate>
     <generator>Jekyll v2.5.3</generator>
     
       <item>

--- a/blog/index.html
+++ b/blog/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" href="http://www.apiman.io/latest/resources/images/favicon.ico">
   <title>apiman blog</title>
-  <meta name="description" content="The apiman project brings an open source development methodology to  API Management, coupling a rich API design & configuration layer with a blazingly fast runtime.  This is the official apiman blog, where we discuss....whatever we're thinking about!
+  <meta name="description" content="The apiman project brings an open source development methodology to API Management, coupling a rich API design & configuration layer with a blazingly fast runtime.  This is the official apiman blog, where we discuss....whatever we're thinking about!
 ">
 
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
@@ -14,7 +14,11 @@
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.css?v=1.1.3.Final" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.responsive.css?v=1.1.3.Final" rel="stylesheet">
+  <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
   <link href="/blog/css/highlight.css" rel="stylesheet">
+  <link href="/blog/css/main.css" rel="stylesheet">
+  <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
+  
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>

--- a/blog/introduction/overview/2015/01/09/impatient-new-user.html
+++ b/blog/introduction/overview/2015/01/09/impatient-new-user.html
@@ -13,7 +13,11 @@
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.css?v=1.1.3.Final" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.responsive.css?v=1.1.3.Final" rel="stylesheet">
+  <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
   <link href="/blog/css/highlight.css" rel="stylesheet">
+  <link href="/blog/css/main.css" rel="stylesheet">
+  <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
+  
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>

--- a/blog/plugins/policies/development/maven/2015/03/06/custom-policies.html
+++ b/blog/plugins/policies/development/maven/2015/03/06/custom-policies.html
@@ -13,7 +13,11 @@
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.css?v=1.1.3.Final" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.responsive.css?v=1.1.3.Final" rel="stylesheet">
+  <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
   <link href="/blog/css/highlight.css" rel="stylesheet">
+  <link href="/blog/css/main.css" rel="stylesheet">
+  <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
+  
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>

--- a/blog/policy/junit/testing/2015/05/09/policy-testing.html
+++ b/blog/policy/junit/testing/2015/05/09/policy-testing.html
@@ -13,7 +13,11 @@
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.css?v=1.1.3.Final" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.responsive.css?v=1.1.3.Final" rel="stylesheet">
+  <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
   <link href="/blog/css/highlight.css" rel="stylesheet">
+  <link href="/blog/css/main.css" rel="stylesheet">
+  <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
+  
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>

--- a/blog/rest/api/automation/2015/05/19/rest-api.html
+++ b/blog/rest/api/automation/2015/05/19/rest-api.html
@@ -13,7 +13,11 @@
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.css?v=1.1.3.Final" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/css/apiman-web.responsive.css?v=1.1.3.Final" rel="stylesheet">
+  <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
   <link href="/blog/css/highlight.css" rel="stylesheet">
+  <link href="/blog/css/main.css" rel="stylesheet">
+  <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
+  
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>


### PR DESCRIPTION
This took me a (very) surprisingly long time to work out, with some undocumented settings used to get it working. This way means that generated images are put in the correct locations during generation, with the correct path put into the HTML for when it's loaded in the browser. 

You may need to do:
    - gem install asciidoctor
    - gem install asciidoctor-diagram --pre

I spent a while chopping up the asciidoctor sass to make some admonition styles that fit with our styles. I didn't want to do anything too outlandish without consulting first, so it's basic. I have some ideas, though, so we should chat about that at some point.

Here's an example of what it looks like:

![screen shot 2015-06-07 at 17 39 14](https://cloud.githubusercontent.com/assets/423513/8024902/2f2b8d6a-0d3c-11e5-814f-097b53da3f68.png)
