### PR TITLE
Fix OAuth2 blog 

### DIFF
--- a/_blog-src/_posts/2015-06-09-keycloak-oauth2.adoc
+++ b/_blog-src/_posts/2015-06-09-keycloak-oauth2.adoc
@@ -15,17 +15,14 @@ Use this pattern to avoid asciidoctor rendering the HTML comment.
 
 == Preparation
 
-For this example, let's assume we're using apiman's http://www.apiman.io/latest/download.html[quickstart] setup:
+For this example, let's assume we're using apiman's http://www.apiman.io/latest/download.html[quickstart] setup and have it running. I suggest using the _'Or simply try this...'_ box.
+
+After you have your apiman quickstart running (replace *apiman-1.1.3.Final* in the path below with whatever version you downloaded), we can live deploy a handy *echo service* into our environment so we have something to test against:
 
 ```ShellSession
-mkdir ~/apiman-1.1.3.Final
-cd ~/apiman-1.1.3.Final
-wget http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.zip
-wget http://downloads.jboss.org/overlord/apiman/1.1.3.Final/apiman-distro-wildfly8-1.1.3.Final-overlay.zip
-unzip wildfly-8.2.0.Final.zip
-unzip -o apiman-distro-wildfly8-1.1.3.Final-overlay.zip -d wildfly-8.2.0.Final
-cd wildfly-8.2.0.Final
-./bin/standalone.sh -c standalone-apiman.xml
+cd ~/apiman-1.1.3.Final/wildfly-8.2.0.Final/apiman/quickstarts/echo-service/
+mvn clean install
+mvn wildfly:deploy
 ```
 
 == Installing the Plugin
@@ -57,7 +54,7 @@ Select *add plugin*, fill in the details as above, and *add plugin*. That's it!
 
 There are two essential components to our system. First, is the http://keycloak.jboss.org[Keycloak server], an all-in-one https://en.wikipedia.org/wiki/Single_sign-on[SSO] and https://en.wikipedia.org/wiki/Identity_management[IdM]; we'll configure it to be our identity source and handle the issuance of OAuth2 bearer tokens. Second, is the apiman OAuth2 policy; we'll set it up to validate the tokens precisely to our requirements.
 
-Let's assume we're going to protect a very simple *echo service*, which echoes back to the requestor the details of any request made to it. It is located at `http://localhost:8080/services/echo`.
+Let's assume we're going to protect a very simple *echo service*, which echoes back to the requestor the details of any request made to it. It is located at `http://localhost:8080/apiman-echo`.
 
 === Keycloak Server
 
@@ -127,7 +124,7 @@ This demonstrates one OAuth2's most useful attributes: all the information requi
 
 First, log into apiman, and *Create a New Organization*; let's call it *_Newcastle_*. Select the *Services* tab, and add a *New Service*; we'll name this one *_EchoService_* and then *Create Service*.
 
-Select the *Implementation* tab, and set the endpoint to our echo service, `http://localhost:8080/services/echo`. Save and move onto the *Plans* tab, where you should opt to *Make this service public*. After saving, we can move onto the *Policies* tab, where the interesting stuff starts.
+Select the *Implementation* tab, and set the endpoint to our echo service, `http://localhost:8080/apiman-echo`. Save and move onto the *Plans* tab, where you should opt to *Make this service public*. After saving, we can move onto the *Policies* tab, where the interesting stuff starts.
 
 Navigate to *Add Policy*, and select *Keycloak OAuth Policy* from the drop-down list. A substantial set of options are available for your perusal, but for the purposes of this blog demo we'll set the following:
 
@@ -178,10 +175,10 @@ Next, let's do a request with a token. There are two ways to attach your bearer 
 - `Authorization` header, as `Authorization: Bearer <token>`
 - `access_token` query parameter, as `http://example.org/the/path/?access_token=<token>`
 
-First, let's retrieve a fresh token, and extract the `access_token` field
+First, let's retrieve a fresh token from Keycloak, and extract the `access_token` field from the json using `jq` footnote:[We're going to use `jq` to select the `access_token` field in our JSON, so if you don't have `jq` installed you can use your package manager to get it: OS X Brew `brew install jq`; On Fedora `sudo yum install jq`; On Debian `sudo apt-get install jq`].
 
 ```
-curl -X POST http://127.0.0.1:8080/auth/realms/stottie/protocol/openid-connect/token  -H "Content-Type: application/x-www-form-urlencoded" -d "username=rincewind" -d 'password=apiman' -d 'grant_type=password' -d 'client_id=apiman' | jsawk 'return this.access_token'
+curl -X POST http://127.0.0.1:8080/auth/realms/stottie/protocol/openid-connect/token  -H "Content-Type: application/x-www-form-urlencoded" -d 'username=rincewind' -d 'password=apiman' -d 'grant_type=password' -d 'client_id=apiman' | jq -r '.access_token'
 ```
 
 Second, we'll take the token and attach it to our request to the service
@@ -190,8 +187,8 @@ Second, we'll take the token and attach it to our request to the service
 [msavy@mmbp tmp]$ curl -k -H "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJiNDY1YW..." https://127.0.0.1:8443/apiman-gateway/Newcastle/EchoService/1.0
 {
   "method" : "GET",
-  "resource" : "/services/echo",
-  "uri" : "/services/echo",
+  "resource" : "/apiman-echo",
+  "uri" : "/apiman-echo",
   "headers" : {
     "Authorization" : "Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJiNDY1YWMzNi1hMTczLTRjOWMtYWJjZS00MzE2MJ...",
     "Host" : "127.0.0.1:8080",
@@ -235,7 +232,6 @@ We're going to add two rules:
 
 |===
 
-
 Our example user has the first role, but not the second. *Add* the policy and *Publish* the service again. Our endpoint will now reflect the changed version.
 
 You will probably need to issue a new bearer token, which you can achieve by repeating the previous shell command.
@@ -245,8 +241,8 @@ You will probably need to issue a new bearer token, which you can achieve by rep
  https://127.0.0.1:8443/apiman-gateway/Newcastle/EchoService/2.0/rincewind/wizard
 {
   "method" : "GET",
-  "resource" : "/services/echo/rincewind/wizard",
-  "uri" : "/services/echo/rincewind/wizard",
+  "resource" : "/apiman-echo/rincewind/wizard",
+  "uri" : "/apiman-echo/rincewind/wizard",
   "headers" : {
     "Authorization" : "Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJmODAyZjFmMy1kN2JmLTQ0YjQtODA2N...",
     "Host" : "127.0.0.1:8080",

--- a/blog/feed.xml
+++ b/blog/feed.xml
@@ -1241,18 +1241,16 @@ You must explicitly enable client authentication for any services you want prote
 &lt;h2 id=&quot;preparation&quot;&gt;Preparation&lt;/h2&gt;
 &lt;div class=&quot;sectionbody&quot;&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
-&lt;p&gt;For this example, let&amp;#8217;s assume we&amp;#8217;re using apiman&amp;#8217;s &lt;a href=&quot;http://www.apiman.io/latest/download.html&quot;&gt;quickstart&lt;/a&gt; setup:&lt;/p&gt;
+&lt;p&gt;For this example, let&amp;#8217;s assume we&amp;#8217;re using apiman&amp;#8217;s &lt;a href=&quot;http://www.apiman.io/latest/download.html&quot;&gt;quickstart&lt;/a&gt; setup and have it running. I suggest using the &lt;em&gt;&#39;Or simply try this&amp;#8230;&amp;#8203;&#39;&lt;/em&gt; box.&lt;/p&gt;
+&lt;/div&gt;
+&lt;div class=&quot;paragraph&quot;&gt;
+&lt;p&gt;After you have your apiman quickstart running (replace &lt;strong&gt;apiman-1.1.3.Final&lt;/strong&gt; in the path below with whatever version you downloaded), we can live deploy a handy &lt;strong&gt;echo service&lt;/strong&gt; into our environment so we have something to test against:&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;listingblock&quot;&gt;
 &lt;div class=&quot;content&quot;&gt;
-&lt;pre class=&quot;CodeRay highlight&quot;&gt;&lt;code data-lang=&quot;ShellSession&quot;&gt;mkdir ~/apiman-1.1.3.Final
-cd ~/apiman-1.1.3.Final
-wget http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.zip
-wget http://downloads.jboss.org/overlord/apiman/1.1.3.Final/apiman-distro-wildfly8-1.1.3.Final-overlay.zip
-unzip wildfly-8.2.0.Final.zip
-unzip -o apiman-distro-wildfly8-1.1.3.Final-overlay.zip -d wildfly-8.2.0.Final
-cd wildfly-8.2.0.Final
-./bin/standalone.sh -c standalone-apiman.xml&lt;/code&gt;&lt;/pre&gt;
+&lt;pre class=&quot;CodeRay highlight&quot;&gt;&lt;code data-lang=&quot;ShellSession&quot;&gt;cd ~/apiman-1.1.3.Final/wildfly-8.2.0.Final/apiman/quickstarts/echo-service/
+mvn clean install
+mvn wildfly:deploy&lt;/code&gt;&lt;/pre&gt;
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;/div&gt;
@@ -1309,7 +1307,7 @@ cd wildfly-8.2.0.Final
 &lt;p&gt;There are two essential components to our system. First, is the &lt;a href=&quot;http://keycloak.jboss.org&quot;&gt;Keycloak server&lt;/a&gt;, an all-in-one &lt;a href=&quot;https://en.wikipedia.org/wiki/Single_sign-on&quot;&gt;SSO&lt;/a&gt; and &lt;a href=&quot;https://en.wikipedia.org/wiki/Identity_management&quot;&gt;IdM&lt;/a&gt;; we&amp;#8217;ll configure it to be our identity source and handle the issuance of OAuth2 bearer tokens. Second, is the apiman OAuth2 policy; we&amp;#8217;ll set it up to validate the tokens precisely to our requirements.&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
-&lt;p&gt;Let&amp;#8217;s assume we&amp;#8217;re going to protect a very simple &lt;strong&gt;echo service&lt;/strong&gt;, which echoes back to the requestor the details of any request made to it. It is located at &lt;code&gt;&lt;a href=&quot;http://localhost:8080/services/echo&quot; class=&quot;bare&quot;&gt;http://localhost:8080/services/echo&lt;/a&gt;&lt;/code&gt;.&lt;/p&gt;
+&lt;p&gt;Let&amp;#8217;s assume we&amp;#8217;re going to protect a very simple &lt;strong&gt;echo service&lt;/strong&gt;, which echoes back to the requestor the details of any request made to it. It is located at &lt;code&gt;&lt;a href=&quot;http://localhost:8080/apiman-echo&quot; class=&quot;bare&quot;&gt;http://localhost:8080/apiman-echo&lt;/a&gt;&lt;/code&gt;.&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;sect2&quot;&gt;
 &lt;h3 id=&quot;keycloak-server&quot;&gt;Keycloak Server&lt;/h3&gt;
@@ -1409,7 +1407,7 @@ There are a huge number of configuration permutations with Keycloak, and the mos
 &lt;p&gt;First, log into apiman, and &lt;strong&gt;Create a New Organization&lt;/strong&gt;; let&amp;#8217;s call it &lt;strong&gt;&lt;em&gt;Newcastle&lt;/em&gt;&lt;/strong&gt;. Select the &lt;strong&gt;Services&lt;/strong&gt; tab, and add a &lt;strong&gt;New Service&lt;/strong&gt;; we&amp;#8217;ll name this one &lt;strong&gt;&lt;em&gt;EchoService&lt;/em&gt;&lt;/strong&gt; and then &lt;strong&gt;Create Service&lt;/strong&gt;.&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
-&lt;p&gt;Select the &lt;strong&gt;Implementation&lt;/strong&gt; tab, and set the endpoint to our echo service, &lt;code&gt;&lt;a href=&quot;http://localhost:8080/services/echo&quot; class=&quot;bare&quot;&gt;http://localhost:8080/services/echo&lt;/a&gt;&lt;/code&gt;. Save and move onto the &lt;strong&gt;Plans&lt;/strong&gt; tab, where you should opt to &lt;strong&gt;Make this service public&lt;/strong&gt;. After saving, we can move onto the &lt;strong&gt;Policies&lt;/strong&gt; tab, where the interesting stuff starts.&lt;/p&gt;
+&lt;p&gt;Select the &lt;strong&gt;Implementation&lt;/strong&gt; tab, and set the endpoint to our echo service, &lt;code&gt;&lt;a href=&quot;http://localhost:8080/apiman-echo&quot; class=&quot;bare&quot;&gt;http://localhost:8080/apiman-echo&lt;/a&gt;&lt;/code&gt;. Save and move onto the &lt;strong&gt;Plans&lt;/strong&gt; tab, where you should opt to &lt;strong&gt;Make this service public&lt;/strong&gt;. After saving, we can move onto the &lt;strong&gt;Policies&lt;/strong&gt; tab, where the interesting stuff starts.&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
 &lt;p&gt;Navigate to &lt;strong&gt;Add Policy&lt;/strong&gt;, and select &lt;strong&gt;Keycloak OAuth Policy&lt;/strong&gt; from the drop-down list. A substantial set of options are available for your perusal, but for the purposes of this blog demo we&amp;#8217;ll set the following:&lt;/p&gt;
@@ -1489,11 +1487,11 @@ There are a huge number of configuration permutations with Keycloak, and the mos
 &lt;/ul&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
-&lt;p&gt;First, let&amp;#8217;s retrieve a fresh token, and extract the &lt;code&gt;access_token&lt;/code&gt; field&lt;/p&gt;
+&lt;p&gt;First, let&amp;#8217;s retrieve a fresh token from Keycloak, and extract the &lt;code&gt;access_token&lt;/code&gt; field from the json using &lt;code&gt;jq&lt;/code&gt; &lt;span class=&quot;footnote&quot;&gt;[&lt;a id=&quot;_footnoteref_3&quot; class=&quot;footnote&quot; href=&quot;#_footnote_3&quot; title=&quot;View footnote.&quot;&gt;3&lt;/a&gt;]&lt;/span&gt;.&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;listingblock&quot;&gt;
 &lt;div class=&quot;content&quot;&gt;
-&lt;pre class=&quot;CodeRay highlight&quot;&gt;&lt;code&gt;curl -X POST http://127.0.0.1:8080/auth/realms/stottie/protocol/openid-connect/token  -H &quot;Content-Type: application/x-www-form-urlencoded&quot; -d &quot;username=rincewind&quot; -d &#39;password=apiman&#39; -d &#39;grant_type=password&#39; -d &#39;client_id=apiman&#39; | jsawk &#39;return this.access_token&#39;&lt;/code&gt;&lt;/pre&gt;
+&lt;pre class=&quot;CodeRay highlight&quot;&gt;&lt;code&gt;curl -X POST http://127.0.0.1:8080/auth/realms/stottie/protocol/openid-connect/token  -H &quot;Content-Type: application/x-www-form-urlencoded&quot; -d &#39;username=rincewind&#39; -d &#39;password=apiman&#39; -d &#39;grant_type=password&#39; -d &#39;client_id=apiman&#39; | jq -r &#39;.access_token&#39;&lt;/code&gt;&lt;/pre&gt;
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
@@ -1504,8 +1502,8 @@ There are a huge number of configuration permutations with Keycloak, and the mos
 &lt;pre class=&quot;CodeRay highlight&quot;&gt;&lt;code&gt;[msavy@mmbp tmp]$ curl -k -H &quot;Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJiNDY1YW...&quot; https://127.0.0.1:8443/apiman-gateway/Newcastle/EchoService/1.0
 {
   &quot;method&quot; : &quot;GET&quot;,
-  &quot;resource&quot; : &quot;/services/echo&quot;,
-  &quot;uri&quot; : &quot;/services/echo&quot;,
+  &quot;resource&quot; : &quot;/apiman-echo&quot;,
+  &quot;uri&quot; : &quot;/apiman-echo&quot;,
   &quot;headers&quot; : {
     &quot;Authorization&quot; : &quot;Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJiNDY1YWMzNi1hMTczLTRjOWMtYWJjZS00MzE2MJ...&quot;,
     &quot;Host&quot; : &quot;127.0.0.1:8080&quot;,
@@ -1591,8 +1589,8 @@ There are a huge number of configuration permutations with Keycloak, and the mos
  https://127.0.0.1:8443/apiman-gateway/Newcastle/EchoService/2.0/rincewind/wizard
 {
   &amp;quot;method&amp;quot; : &amp;quot;GET&amp;quot;,
-  &amp;quot;resource&amp;quot; : &amp;quot;/services/echo/rincewind/wizard&amp;quot;,
-  &amp;quot;uri&amp;quot; : &amp;quot;/services/echo/rincewind/wizard&amp;quot;,
+  &amp;quot;resource&amp;quot; : &amp;quot;/apiman-echo/rincewind/wizard&amp;quot;,
+  &amp;quot;uri&amp;quot; : &amp;quot;/apiman-echo/rincewind/wizard&amp;quot;,
   &amp;quot;headers&amp;quot; : {
     &amp;quot;Authorization&amp;quot; : &amp;quot;Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJmODAyZjFmMy1kN2JmLTQ0YjQtODA2N...&amp;quot;,
     &amp;quot;Host&amp;quot; : &amp;quot;127.0.0.1:8080&amp;quot;,
@@ -1645,6 +1643,9 @@ There are a huge number of configuration permutations with Keycloak, and the mos
 &lt;/div&gt;
 &lt;div class=&quot;footnote&quot; id=&quot;_footnote_2&quot;&gt;
 &lt;a href=&quot;#_footnoteref_2&quot;&gt;2&lt;/a&gt; Ensure you use whatever the valid ISS value is for your Keycloak realm. One quick way to find this is by decoding an access_token looking at what Keycloak has set for the &lt;code&gt;iss&lt;/code&gt; field
+&lt;/div&gt;
+&lt;div class=&quot;footnote&quot; id=&quot;_footnote_3&quot;&gt;
+&lt;a href=&quot;#_footnoteref_3&quot;&gt;3&lt;/a&gt; We&amp;#8217;re going to use &lt;code&gt;jq&lt;/code&gt; to select the &lt;code&gt;access_token&lt;/code&gt; field in our JSON, so if you don&amp;#8217;t have &lt;code&gt;jq&lt;/code&gt; installed you can use your package manager to get it: OS X Brew &lt;code&gt;brew install jq&lt;/code&gt;; On Fedora &lt;code&gt;sudo yum install jq&lt;/code&gt;; On Debian &lt;code&gt;sudo apt-get install jq&lt;/code&gt;
 &lt;/div&gt;
 &lt;/div&gt;</description>
 				
@@ -3153,6 +3154,6 @@ Resolving deltas: 100% (40/40), done.
 				<guid isPermaLink="true">http://apiman.io/blog/introduction/overview/2015/01/09/impatient-new-user.html</guid>
 			</item>
 		
-		<lastBuildDate>Wed, 08 Jul 2015 09:16:57 -0400</lastBuildDate>
+		<lastBuildDate>Wed, 08 Jul 2015 12:57:38 -0400</lastBuildDate>
 	</channel>
 </rss>

--- a/blog/gateway/security/oauth2/keycloak/authentication/authorization/2015/06/09/keycloak-oauth2.html
+++ b/blog/gateway/security/oauth2/keycloak/authentication/authorization/2015/06/09/keycloak-oauth2.html
@@ -130,18 +130,16 @@
 <h2 id="preparation">Preparation</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>For this example, let&#8217;s assume we&#8217;re using apiman&#8217;s <a href="http://www.apiman.io/latest/download.html">quickstart</a> setup:</p>
+<p>For this example, let&#8217;s assume we&#8217;re using apiman&#8217;s <a href="http://www.apiman.io/latest/download.html">quickstart</a> setup and have it running. I suggest using the <em>'Or simply try this&#8230;&#8203;'</em> box.</p>
+</div>
+<div class="paragraph">
+<p>After you have your apiman quickstart running (replace <strong>apiman-1.1.3.Final</strong> in the path below with whatever version you downloaded), we can live deploy a handy <strong>echo service</strong> into our environment so we have something to test against:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="ShellSession">mkdir ~/apiman-1.1.3.Final
-cd ~/apiman-1.1.3.Final
-wget http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.zip
-wget http://downloads.jboss.org/overlord/apiman/1.1.3.Final/apiman-distro-wildfly8-1.1.3.Final-overlay.zip
-unzip wildfly-8.2.0.Final.zip
-unzip -o apiman-distro-wildfly8-1.1.3.Final-overlay.zip -d wildfly-8.2.0.Final
-cd wildfly-8.2.0.Final
-./bin/standalone.sh -c standalone-apiman.xml</code></pre>
+<pre class="CodeRay highlight"><code data-lang="ShellSession">cd ~/apiman-1.1.3.Final/wildfly-8.2.0.Final/apiman/quickstarts/echo-service/
+mvn clean install
+mvn wildfly:deploy</code></pre>
 </div>
 </div>
 </div>
@@ -198,7 +196,7 @@ cd wildfly-8.2.0.Final
 <p>There are two essential components to our system. First, is the <a href="http://keycloak.jboss.org">Keycloak server</a>, an all-in-one <a href="https://en.wikipedia.org/wiki/Single_sign-on">SSO</a> and <a href="https://en.wikipedia.org/wiki/Identity_management">IdM</a>; we&#8217;ll configure it to be our identity source and handle the issuance of OAuth2 bearer tokens. Second, is the apiman OAuth2 policy; we&#8217;ll set it up to validate the tokens precisely to our requirements.</p>
 </div>
 <div class="paragraph">
-<p>Let&#8217;s assume we&#8217;re going to protect a very simple <strong>echo service</strong>, which echoes back to the requestor the details of any request made to it. It is located at <code><a href="http://localhost:8080/services/echo" class="bare">http://localhost:8080/services/echo</a></code>.</p>
+<p>Let&#8217;s assume we&#8217;re going to protect a very simple <strong>echo service</strong>, which echoes back to the requestor the details of any request made to it. It is located at <code><a href="http://localhost:8080/apiman-echo" class="bare">http://localhost:8080/apiman-echo</a></code>.</p>
 </div>
 <div class="sect2">
 <h3 id="keycloak-server">Keycloak Server</h3>
@@ -298,7 +296,7 @@ There are a huge number of configuration permutations with Keycloak, and the mos
 <p>First, log into apiman, and <strong>Create a New Organization</strong>; let&#8217;s call it <strong><em>Newcastle</em></strong>. Select the <strong>Services</strong> tab, and add a <strong>New Service</strong>; we&#8217;ll name this one <strong><em>EchoService</em></strong> and then <strong>Create Service</strong>.</p>
 </div>
 <div class="paragraph">
-<p>Select the <strong>Implementation</strong> tab, and set the endpoint to our echo service, <code><a href="http://localhost:8080/services/echo" class="bare">http://localhost:8080/services/echo</a></code>. Save and move onto the <strong>Plans</strong> tab, where you should opt to <strong>Make this service public</strong>. After saving, we can move onto the <strong>Policies</strong> tab, where the interesting stuff starts.</p>
+<p>Select the <strong>Implementation</strong> tab, and set the endpoint to our echo service, <code><a href="http://localhost:8080/apiman-echo" class="bare">http://localhost:8080/apiman-echo</a></code>. Save and move onto the <strong>Plans</strong> tab, where you should opt to <strong>Make this service public</strong>. After saving, we can move onto the <strong>Policies</strong> tab, where the interesting stuff starts.</p>
 </div>
 <div class="paragraph">
 <p>Navigate to <strong>Add Policy</strong>, and select <strong>Keycloak OAuth Policy</strong> from the drop-down list. A substantial set of options are available for your perusal, but for the purposes of this blog demo we&#8217;ll set the following:</p>
@@ -378,11 +376,11 @@ There are a huge number of configuration permutations with Keycloak, and the mos
 </ul>
 </div>
 <div class="paragraph">
-<p>First, let&#8217;s retrieve a fresh token, and extract the <code>access_token</code> field</p>
+<p>First, let&#8217;s retrieve a fresh token from Keycloak, and extract the <code>access_token</code> field from the json using <code>jq</code> <span class="footnote">[<a id="_footnoteref_3" class="footnote" href="#_footnote_3" title="View footnote.">3</a>]</span>.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code>curl -X POST http://127.0.0.1:8080/auth/realms/stottie/protocol/openid-connect/token  -H "Content-Type: application/x-www-form-urlencoded" -d "username=rincewind" -d 'password=apiman' -d 'grant_type=password' -d 'client_id=apiman' | jsawk 'return this.access_token'</code></pre>
+<pre class="CodeRay highlight"><code>curl -X POST http://127.0.0.1:8080/auth/realms/stottie/protocol/openid-connect/token  -H "Content-Type: application/x-www-form-urlencoded" -d 'username=rincewind' -d 'password=apiman' -d 'grant_type=password' -d 'client_id=apiman' | jq -r '.access_token'</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -393,8 +391,8 @@ There are a huge number of configuration permutations with Keycloak, and the mos
 <pre class="CodeRay highlight"><code>[msavy@mmbp tmp]$ curl -k -H "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJiNDY1YW..." https://127.0.0.1:8443/apiman-gateway/Newcastle/EchoService/1.0
 {
   "method" : "GET",
-  "resource" : "/services/echo",
-  "uri" : "/services/echo",
+  "resource" : "/apiman-echo",
+  "uri" : "/apiman-echo",
   "headers" : {
     "Authorization" : "Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJiNDY1YWMzNi1hMTczLTRjOWMtYWJjZS00MzE2MJ...",
     "Host" : "127.0.0.1:8080",
@@ -480,8 +478,8 @@ There are a huge number of configuration permutations with Keycloak, and the mos
  https://127.0.0.1:8443/apiman-gateway/Newcastle/EchoService/2.0/rincewind/wizard
 {
   &quot;method&quot; : &quot;GET&quot;,
-  &quot;resource&quot; : &quot;/services/echo/rincewind/wizard&quot;,
-  &quot;uri&quot; : &quot;/services/echo/rincewind/wizard&quot;,
+  &quot;resource&quot; : &quot;/apiman-echo/rincewind/wizard&quot;,
+  &quot;uri&quot; : &quot;/apiman-echo/rincewind/wizard&quot;,
   &quot;headers&quot; : {
     &quot;Authorization&quot; : &quot;Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJmODAyZjFmMy1kN2JmLTQ0YjQtODA2N...&quot;,
     &quot;Host&quot; : &quot;127.0.0.1:8080&quot;,
@@ -534,6 +532,9 @@ There are a huge number of configuration permutations with Keycloak, and the mos
 </div>
 <div class="footnote" id="_footnote_2">
 <a href="#_footnoteref_2">2</a> Ensure you use whatever the valid ISS value is for your Keycloak realm. One quick way to find this is by decoding an access_token looking at what Keycloak has set for the <code>iss</code> field
+</div>
+<div class="footnote" id="_footnote_3">
+<a href="#_footnoteref_3">3</a> We&#8217;re going to use <code>jq</code> to select the <code>access_token</code> field in our JSON, so if you don&#8217;t have <code>jq</code> installed you can use your package manager to get it: OS X Brew <code>brew install jq</code>; On Fedora <code>sudo yum install jq</code>; On Debian <code>sudo apt-get install jq</code>
 </div>
 </div>
   </article>


### PR DESCRIPTION
Thanks to @cmoulliard for spotting those errors.

As `jsawk` doesn't seem to be available on Fedora, I've switched to a different CLI-based json parser called `jq`.