### PR TITLE
Make references to old/new posts work

### DIFF
--- a/_blog-src/_layouts/post.html
+++ b/_blog-src/_layouts/post.html
@@ -16,7 +16,14 @@ layout: default
     <!-- Old Post -->
     <p class="bg-warning"
        style="margin-top:15px; padding: 10px;">
-        Note: A newer revision of this blogpost for <b>apiman 1.2.x</b> can be found <a href="{{ site.url }}{{ site.baseurl }}/{{ page.newUrl }}">here</a>. This version was written for <b>apiman 1.1.x</b>.
+        Note: A newer revision of this blogpost for <b>apiman 1.2.x</b> can be found <a href="
+        {% for post in site.posts %}
+              {% assign postName = post.path | find_post_by_name %}
+              {% if postName == page.newUrl %}
+                {{ site.url }}{{ site.baseurl }}{{ post.url }}
+              {% endif %}
+        {% endfor %}
+           ">here</a>. This version was written for <b>apiman 1.1.x</b>.
     </p>
   {% endif %}
 
@@ -24,7 +31,14 @@ layout: default
     <!-- New Post -->
     <p class="bg-warning"
        style="margin-top:15px; padding: 10px;">
-        Note: This is a redux of our blogpost for <b>apiman 1.2.x</b>. If you're still using <b>apiman 1.1.x</b>, you can refer to the <a href="{{ site.url }}{{ site.baseurl }}/{{ page.oldUrl }}">older revision</a>.
+        Note: This is a redux of our blogpost for <b>apiman 1.2.x</b>. If you're still using <b>apiman 1.1.x</b>, you can refer to the <a href="
+        {% for post in site.posts %}
+              {% assign postName = post.path | find_post_by_name %}
+              {% if postName == page.oldUrl %}
+                {{ site.url }}{{ site.baseurl }}{{ post.url }}
+              {% endif %}
+        {% endfor %}
+        ">older revision</a>.
     </p>
   {% endif %}
 

--- a/_blog-src/_layouts/post.html
+++ b/_blog-src/_layouts/post.html
@@ -18,7 +18,7 @@ layout: default
        style="margin-top:15px; padding: 10px;">
         Note: A newer revision of this blogpost for <b>apiman 1.2.x</b> can be found <a href="
         {% for post in site.posts %}
-              {% assign postName = post.path | find_post_by_name %}
+              {% assign postName = post.path | find_post_by_path %}
               {% if postName == page.newUrl %}
                 {{ site.url }}{{ site.baseurl }}{{ post.url }}
               {% endif %}
@@ -33,7 +33,7 @@ layout: default
        style="margin-top:15px; padding: 10px;">
         Note: This is a redux of our blogpost for <b>apiman 1.2.x</b>. If you're still using <b>apiman 1.1.x</b>, you can refer to the <a href="
         {% for post in site.posts %}
-              {% assign postName = post.path | find_post_by_name %}
+              {% assign postName = post.path | find_post_by_path %}
               {% if postName == page.oldUrl %}
                 {{ site.url }}{{ site.baseurl }}{{ post.url }}
               {% endif %}

--- a/_blog-src/_plugins/find_post_by_name.rb
+++ b/_blog-src/_plugins/find_post_by_name.rb
@@ -1,0 +1,13 @@
+require 'uri'
+
+module Jekyll
+  module FindPostByNameFilter
+    def find_post_by_name( input )
+      url = URI(input)
+      extname = File.extname(url.path) || ""
+      url.path.split("/").last.chomp(extname)
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::FindPostByNameFilter)

--- a/_blog-src/_plugins/find_post_by_path.rb
+++ b/_blog-src/_plugins/find_post_by_path.rb
@@ -1,8 +1,8 @@
 require 'uri'
 
 module Jekyll
-  module FindPostByNameFilter
-    def find_post_by_name( input )
+  module FindPostByPathFilter
+    def find_post_by_path( input )
       url = URI(input)
       extname = File.extname(url.path) || ""
       url.path.split("/").last.chomp(extname)
@@ -10,4 +10,4 @@ module Jekyll
   end
 end
 
-Liquid::Template.register_filter(Jekyll::FindPostByNameFilter)
+Liquid::Template.register_filter(Jekyll::FindPostByPathFilter)


### PR DESCRIPTION
Decidedly more complicated than I'd expected, annoyingly.

As we've figured out, Jekyll doesn't necessarily play nicely when its in a subdirectory... So the links when generated link to apiman.io rather than localhost which might throw you off.

Perhaps it's fixed in a newer version of Jekyll, but it doesn't seem worth the effort for now.

@Kahboom, @EricWittmann - seem reasonable?