### PR TITLE
re #808 Add Bing meta tag to head on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <html> 
   <head>
     <title>apiman | Open Source API Management</title>
+    <meta name="msvalidate.01" content="C3BF2C67B92C75F2DEAA096973652038" />
     <META http-equiv="refresh" content="0;URL=latest"> 
   </head> 
   <body bgcolor="#ffffff"> 

--- a/latest/index.html
+++ b/latest/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+      <meta name="msvalidate.01" content="C3BF2C67B92C75F2DEAA096973652038" />
     <link rel="shortcut icon" href="resources/images/favicon.ico">
     <title>apiman | Open Source API Management</title>
 


### PR DESCRIPTION
Sorry about this; forgot to add the verification tag to the `head` for both landing pages (just in case it couldn't verify from /latest) for Bing Webmaster Tools.

JIRA: https://issues.jboss.org/browse/APIMAN-808

Ref: https://www.bing.com/webmaster/configure/verify/ownership?url=http%3A%2F%2Fapiman.io%2F

cc @EricWittmann 