### PR TITLE
Minor fixes for the blog

### DIFF
--- a/_blog-src/_posts/2015-01-09-impatient-new-user-redux.markdown
+++ b/_blog-src/_posts/2015-01-09-impatient-new-user-redux.markdown
@@ -118,13 +118,13 @@ The sequence in which incoming API requests have policies applied is:
 
 What happens is that when an API request is received by the API Gateway at runtime, the policy chain is applied in the order of client app, plan, and API. If no failures, such as a rate counter being exceeded, occur, the API Gateway sends the request to the API. As we mentioned earlier in this post, the API Gateway acts as a proxy for the API:
 
-![Diagram_2](/blog/images/2015-01-09/apiman_3-redux.jpg)
+![Diagram_2](/blog/images/2015-01-09/apiman_3-redux.png)
 
 Next, when the API Gateway receives a response from the API's backend implementation, the policy chain is applied again, but this time in the reverse order. The API policies are applied first, then the plan policies, and finally the client app policies. If no failures occur, then the API response is sent back to the consumer of the API.
 
 By applying the policy chain twice, both for the originating incoming request and the resulting response, apiman allows policy implementations two opportunities to provide management functionality during the lifecycle. The following diagram illustrates this two-way approach to applying policies:
 
-![Diagram_3](/blog/images/2015-01-09/apiman_4-redux.jpg)
+![Diagram_3](/blog/images/2015-01-09/apiman_4-redux.png)
 
 ## Plans
 

--- a/_blog-src/_posts/2015-06-11-basic-auth-redux.markdown
+++ b/_blog-src/_posts/2015-06-11-basic-auth-redux.markdown
@@ -4,7 +4,7 @@ title:  "Adding a BASIC Authentication Policy to a Managed API in JBoss apiman"
 date:   2015-06-11 11:00:00
 author: len_dimaggio
 categories: authentication policy
-oldUrl: 2015-06-11-basic-auth-redux
+oldUrl: 2015-06-11-basic-auth
 ---
 
 ![apiman logo](/blog/images/2015-06-11/1-apiman_logo.png)


### PR DESCRIPTION
Changes:
- Updated image file type for a redux post, which were causing images not to load.
- Fixed an oldUrl link that was incorrect

cc @EricWittmann  - The blog post I was referring to (here: http://127.0.0.1:4000/blog/api-manager/swagger/api/ui/2015/06/02/swagger-redux.html) is going to link to a broken 'old URL' because we had to change the tag name from 'service' to 'api', and this doesn't yet exist remotely (tags are used in the post URL). However, once we publish the changes it should work in production, as we updated the 'old post' to include the 'api' tag instead of the 'service' tag.