### PR TITLE
re #1049 Adobe analytics tracking code

### DIFF
--- a/_blog-src/_includes/footer.html
+++ b/_blog-src/_includes/footer.html
@@ -17,4 +17,67 @@
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>

--- a/_blog-src/_includes/head.html
+++ b/_blog-src/_includes/head.html
@@ -7,6 +7,7 @@
   <title>{% if page.title %}{{ page.title }} | apiman Open Source API Management{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -16,7 +17,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -26,18 +30,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     {% if page.newUrl %}
     <link rel="canonical" href="{% for post in site.posts %}
               {% assign postName = post.path | find_post_by_path %}
@@ -50,4 +44,18 @@
     {% endif %}
 
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>

--- a/blog/about/index.html
+++ b/blog/about/index.html
@@ -10,6 +10,7 @@
   <meta name="description" content="The apiman project brings an open source development methodology to API Management, coupling a rich API design & configuration layer with a blazingly fast runtime.  This is the official apiman blog, where we discuss....whatever we're thinking about!
 ">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -19,7 +20,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -29,23 +33,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/about/">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -159,6 +167,69 @@
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/api-manager/api-gateway/plugins/development/maven/2015/07/24/plugin-components-redux.html
+++ b/blog/api-manager/api-gateway/plugins/development/maven/2015/07/24/plugin-components-redux.html
@@ -9,6 +9,7 @@
   <title>Plugins - Not Just For Policies Anymore | apiman Open Source API Management</title>
   <meta name="description" content="As you may know, apiman has long supported custom policies provided by users.  If youaren’t familiar with apiman plugins, you can find more about them by cli...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/api-manager/api-gateway/plugins/development/maven/2015/07/24/plugin-components-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -531,6 +539,69 @@ provide an easy way for users (and the apiman community at large) to contribute.
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/api-manager/api-gateway/plugins/development/maven/2015/07/24/plugin-components.html
+++ b/blog/api-manager/api-gateway/plugins/development/maven/2015/07/24/plugin-components.html
@@ -9,6 +9,7 @@
   <title>Plugins - Not Just For Policies Anymore | apiman Open Source API Management</title>
   <meta name="description" content="As you may know, apiman has long supported custom policies provided by users.  If youaren’t familiar with apiman plugins, you can find more about them by cli...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -659,6 +667,69 @@ provide an easy way for users (and the apiman community at large) to contribute.
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/api-manager/api/ui/metrics/2015/07/06/metrics-redux.html
+++ b/blog/api-manager/api/ui/metrics/2015/07/06/metrics-redux.html
@@ -9,6 +9,7 @@
   <title>At long last, Metrics R Us! | apiman Open Source API Management</title>
   <meta name="description" content="A core feature of any good API Management solution is the recording of and reporting oninteresting metrics related to API requests.  Because apiman acts as a...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/api-manager/api/ui/metrics/2015/07/06/metrics-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -424,6 +432,69 @@ or <a href="http://www.apiman.io/latest/chat.html">IRC channel</a>.</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/api-manager/service/ui/metrics/2015/07/06/metrics.html
+++ b/blog/api-manager/service/ui/metrics/2015/07/06/metrics.html
@@ -9,6 +9,7 @@
   <title>At long last, Metrics R Us! | apiman Open Source API Management</title>
   <meta name="description" content="A core feature of any good API Management solution is the recording of and reporting oninteresting metrics related to API requests.  Because apiman acts as a...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -552,6 +560,69 @@ or <a href="http://www.apiman.io/latest/chat.html">IRC channel</a>.</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/api-manager/swagger/api/ui/2015/06/02/swagger-redux.html
+++ b/blog/api-manager/swagger/api/ui/2015/06/02/swagger-redux.html
@@ -9,6 +9,7 @@
   <title>We got the moves like swagger! | apiman Open Source API Management</title>
   <meta name="description" content="One of the weaknesses we’ve had in apiman until now is that API providers didn’t haveany way to document how to consume their APIs.  Well that has all change...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/api-manager/swagger/api/ui/2015/06/02/swagger-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -354,6 +362,69 @@ API as described by the Swagger spec definition:</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/api-manager/swagger/api/ui/2015/06/02/swagger.html
+++ b/blog/api-manager/swagger/api/ui/2015/06/02/swagger.html
@@ -9,6 +9,7 @@
   <title>We got the moves like swagger! | apiman Open Source API Management</title>
   <meta name="description" content="One of the weaknesses we’ve had in apiman until now is that service providers didn’t haveany way to document how to consume their services.  Well that has al...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -482,6 +490,69 @@ service as described by the Swagger spec definition:</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/api/management/jboss/fuse/2015/07/07/fuse-apis-redux.html
+++ b/blog/api/management/jboss/fuse/2015/07/07/fuse-apis-redux.html
@@ -9,6 +9,7 @@
   <title>Manage Fuse APIs with apiman | apiman Open Source API Management</title>
   <meta name="description" content="This article aims to provide a short guide on how to get API Management capabilities provided by apiman to work with JBoss Fuse, a lightweight, flexible, int...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/api/management/jboss/fuse/2015/07/07/fuse-apis-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -453,6 +461,69 @@ X-RateLimit-Reset: 8
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/api/management/jboss/fuse/2015/07/07/fuse-apis.html
+++ b/blog/api/management/jboss/fuse/2015/07/07/fuse-apis.html
@@ -9,6 +9,7 @@
   <title>Manage Fuse APIs with apiman | apiman Open Source API Management</title>
   <meta name="description" content="This article aims to provide a short guide on how to get API Management capabilities provided by apiman to work with JBoss Fuse, a lightweight, flexible, int...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -581,6 +589,69 @@ X-RateLimit-Reset: 8
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/apiman/1.2.x/2016/01/27/renaming.html
+++ b/blog/apiman/1.2.x/2016/01/27/renaming.html
@@ -9,6 +9,7 @@
   <title>Apiman Names Have Been Changed to Protect the Guilty | apiman Open Source API Management</title>
   <meta name="description" content="Recently we released version 1.2 of apiman and part of that release includes an effortto rename some concepts to make them more clear (or to better align the...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/apiman/1.2.x/2016/01/27/renaming.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -230,6 +238,69 @@ users.  We certainly hope that these name changes help with that goal.</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/apiman/1.2.x/gateway/2016/02/24/republishing.html
+++ b/blog/apiman/1.2.x/gateway/2016/02/24/republishing.html
@@ -9,6 +9,7 @@
   <title>Re-Publishing Your API(s) | apiman Open Source API Management</title>
   <meta name="description" content="An early design decision we made in apiman was to not allow APIs to bere-published to the Gateway.  The reasoning was that Client Apps may haveestablished Co...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/apiman/1.2.x/gateway/2016/02/24/republishing.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -222,6 +230,69 @@ being republished!</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/apiman/1.2.x/gateway/2016/02/24/reregistering.html
+++ b/blog/apiman/1.2.x/gateway/2016/02/24/reregistering.html
@@ -9,6 +9,7 @@
   <title>Re-Registering Your Client App(s) | apiman Open Source API Management</title>
   <meta name="description" content="In a recent blog post I explained why APIs used to be completely frozen once they were published, and how we have loosened that restriction forPublic APIs.  ...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/apiman/1.2.x/gateway/2016/02/24/reregistering.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -195,6 +203,69 @@ changes to the gateway!</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/apiman/1.2.x/gateway/jdbc/registry/2016/03/09/jdbc-registry.html
+++ b/blog/apiman/1.2.x/gateway/jdbc/registry/2016/03/09/jdbc-registry.html
@@ -9,6 +9,7 @@
   <title>Storing Your Gateway Config in a Database | apiman Open Source API Management</title>
   <meta name="description" content="One of the strongest features of apiman, in general, is its excellentextensibility.  Not only is it easy to add new policies, for example,but many of its cor...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/apiman/1.2.x/gateway/jdbc/registry/2016/03/09/jdbc-registry.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -273,6 +281,69 @@ components for alternatives (e.g. Rate Limiting, Caching, etc).</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/apiman/1.2.x/manager/catalog/2016/03/23/api-catalog.html
+++ b/blog/apiman/1.2.x/manager/catalog/2016/03/23/api-catalog.html
@@ -9,6 +9,7 @@
   <title>Import APIs Into Apiman (API Catalog) | apiman Open Source API Management</title>
   <meta name="description" content="One of the less enjoyable aspects of apiman is the manual addition of an APIthat you wish to manage.  And if you have a bunch of APIs you want to manage,you ...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/apiman/1.2.x/manager/catalog/2016/03/23/api-catalog.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -311,6 +319,69 @@ tomorrow!</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/apiman/2016/01/22/release-1.2.html
+++ b/blog/apiman/2016/01/22/release-1.2.html
@@ -9,6 +9,7 @@
   <title>Finally!  Apiman 1.2.1.Final is released! | apiman Open Source API Management</title>
   <meta name="description" content="It’s been ages since apiman had a new release!  Well the reason for that is we’ve beenpushing to get the first version of 1.2.x out the door.  I’m here to te...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/apiman/2016/01/22/release-1.2.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -254,6 +262,69 @@ designed to satisfy the following use-cases:</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/apiman/introduction/overview/backup/export/import/2016/01/27/export-import.html
+++ b/blog/apiman/introduction/overview/backup/export/import/2016/01/27/export-import.html
@@ -9,6 +9,7 @@
   <title>Apiman 1.2.1 Export and Import | apiman Open Source API Management</title>
   <meta name="description" content="The Question you DreadIf you use a computer at home or at work, you’ll eventually find yourself in a situation where you lose some important data and, while ...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/apiman/introduction/overview/backup/export/import/2016/01/27/export-import.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -321,6 +329,69 @@ A production environment, where the goal is stability. This is the environment t
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/apiman/introduction/overview/plugin/management/2016/02/22/plugin-mgmt.html
+++ b/blog/apiman/introduction/overview/plugin/management/2016/02/22/plugin-mgmt.html
@@ -9,6 +9,7 @@
   <title>Apiman 1.2 - Improvements to Plugin Management | apiman Open Source API Management</title>
   <meta name="description" content="Apiman is not only preconfigured with a rich set of policies that you can use, right out of the box, but, from its earliest releases, apiman has also include...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/apiman/introduction/overview/plugin/management/2016/02/22/plugin-mgmt.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -453,6 +461,69 @@
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/authentication/policy/2015/06/11/basic-auth-redux.html
+++ b/blog/authentication/policy/2015/06/11/basic-auth-redux.html
@@ -9,6 +9,7 @@
   <title>Adding a BASIC Authentication Policy to a Managed API in JBoss apiman | apiman Open Source API Management</title>
   <meta name="description" content="In this, the fourth article in the series on apiman, JBoss’ new API Management framework, we’ll examine how apiman enables you to not just manage APIs, but i...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/authentication/policy/2015/06/11/basic-auth-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -445,6 +453,69 @@
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/authentication/policy/2015/06/11/basic-auth.html
+++ b/blog/authentication/policy/2015/06/11/basic-auth.html
@@ -9,6 +9,7 @@
   <title>Adding a BASIC Authentication Policy to a Managed Service in JBoss apiman | apiman Open Source API Management</title>
   <meta name="description" content="In this, the fourth article in the series on apiman, JBoss’ new API Management framework, we’ll examine how apiman enables you to not just manage services, b...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -573,6 +581,69 @@
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/authorization/authentication/policy/2015/05/08/authorization-redux.html
+++ b/blog/authorization/authentication/policy/2015/05/08/authorization-redux.html
@@ -9,6 +9,7 @@
   <title>Authorization: good god, what is it good for? | apiman Open Source API Management</title>
   <meta name="description" content="Quite a bit, actually.  :)I want to talk about how Authorization currently works in apiman, because it’sa little bit more loosely coupled than you might expe...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/authorization/authentication/policy/2015/05/08/authorization-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -365,6 +373,69 @@ extracting the user’s roles and passing them along to the Authorization policy
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/authorization/authentication/policy/2015/05/08/authorization.html
+++ b/blog/authorization/authentication/policy/2015/05/08/authorization.html
@@ -9,6 +9,7 @@
   <title>Authorization: good god, what is it good for? | apiman Open Source API Management</title>
   <meta name="description" content="Quite a bit, actually.  :)I want to talk about how Authorization currently works in apiman, because it’sa little bit more loosely coupled than you might expe...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -493,6 +501,69 @@ extracting the user’s roles and passing them along to the Authorization policy
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/eclipse/development/maven/2015/06/04/dev-environment-redux.html
+++ b/blog/eclipse/development/maven/2015/06/04/dev-environment-redux.html
@@ -9,6 +9,7 @@
   <title>Setting up your apiman development environment | apiman Open Source API Management</title>
   <meta name="description" content="For those of you who might be interested in hacking away at some core apiman code,I thought it might be nice to create a reasonably comprehensive step-by-ste...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/eclipse/development/maven/2015/06/04/dev-environment-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -508,6 +516,69 @@ processes again.</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/eclipse/development/maven/2015/06/04/dev-environment.html
+++ b/blog/eclipse/development/maven/2015/06/04/dev-environment.html
@@ -9,6 +9,7 @@
   <title>Setting up your apiman development environment | apiman Open Source API Management</title>
   <meta name="description" content="For those of you who might be interested in hacking away at some core apiman code,I thought it might be nice to create a reasonably comprehensive step-by-ste...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -636,6 +644,69 @@ processes again.</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/feed.xml
+++ b/blog/feed.xml
@@ -5761,6 +5761,6 @@ processes again.&lt;/p&gt;
 				<guid isPermaLink="true">http://apiman.io/blog/eclipse/development/maven/2015/06/04/dev-environment.html</guid>
 			</item>
 		
-		<lastBuildDate>Wed, 23 Mar 2016 16:36:03 -0400</lastBuildDate>
+		<lastBuildDate>Thu, 24 Mar 2016 11:29:51 -0400</lastBuildDate>
 	</channel>
 </rss>

--- a/blog/gateway/security/mutual-auth/ssl/mtls/1.2.x/2016/01/22/mtls-mutual-auth-redux.html
+++ b/blog/gateway/security/mutual-auth/ssl/mtls/1.2.x/2016/01/22/mtls-mutual-auth-redux.html
@@ -9,6 +9,7 @@
   <title>Cover yourself up! Protecting your APIs with mutual auth | apiman Open Source API Management</title>
   <meta name="description" content="The last thing you want after carefully setting up your system with apiman is for someone to be able to call around the gateway and hit your APIs directly. T...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/gateway/security/mutual-auth/ssl/mtls/1.2.x/2016/01/22/mtls-mutual-auth-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -542,6 +550,69 @@ You must explicitly enable client authentication for any APIs you want protected
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/gateway/security/mutual-auth/ssl/mtls/2015/06/16/mtls-mutual-auth.html
+++ b/blog/gateway/security/mutual-auth/ssl/mtls/2015/06/16/mtls-mutual-auth.html
@@ -9,6 +9,7 @@
   <title>Cover yourself up! Protecting your services with mutual auth | apiman Open Source API Management</title>
   <meta name="description" content="The last thing you want after carefully setting up your system with apiman is for someone to be able to call around the gateway and hit your services directl...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -673,6 +681,69 @@ You must explicitly enable client authentication for any services you want prote
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/gateway/security/oauth2/keycloak/authentication/authorization/1.2.x/2016/01/22/keycloak-oauth2-redux.html
+++ b/blog/gateway/security/oauth2/keycloak/authentication/authorization/1.2.x/2016/01/22/keycloak-oauth2-redux.html
@@ -9,6 +9,7 @@
   <title>Keycloak and dagger: Securing your APIs with OAuth2 | apiman Open Source API Management</title>
   <meta name="description" content="One great advantage of API Management is centralising auth concerns, thereby avoiding burdensome reimplementation issues and streamlining your security proce...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/gateway/security/oauth2/keycloak/authentication/authorization/1.2.x/2016/01/22/keycloak-oauth2-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -710,6 +718,69 @@ There are a huge number of configuration permutations with Keycloak, and the mos
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/gateway/security/oauth2/keycloak/authentication/authorization/2015/06/09/keycloak-oauth2.html
+++ b/blog/gateway/security/oauth2/keycloak/authentication/authorization/2015/06/09/keycloak-oauth2.html
@@ -9,6 +9,7 @@
   <title>Keycloak and dagger: Securing your services with OAuth2 | apiman Open Source API Management</title>
   <meta name="description" content="One great advantage of API Management is centralising auth concerns, thereby avoiding burdensome reimplementation issues and streamlining your security proce...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -849,6 +857,69 @@ There are a huge number of configuration permutations with Keycloak, and the mos
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -10,6 +10,7 @@
   <meta name="description" content="The apiman project brings an open source development methodology to API Management, coupling a rich API design & configuration layer with a blazingly fast runtime.  This is the official apiman blog, where we discuss....whatever we're thinking about!
 ">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -19,7 +20,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -29,23 +33,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -862,6 +870,69 @@ sources. The applications often consume these services through their APIs.</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/introduction/overview/2015/01/09/impatient-new-user-redux.html
+++ b/blog/introduction/overview/2015/01/09/impatient-new-user-redux.html
@@ -9,6 +9,7 @@
   <title>An Impatient New User's Introduction to API Management with JBoss apiman 1.0 | apiman Open Source API Management</title>
   <meta name="description" content="Software application development models are evolutionary things. New technologies are always being createdand require new approaches. It’s frequently the cas...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/introduction/overview/2015/01/09/impatient-new-user-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -764,6 +772,69 @@ Resolving deltas: 100% (40/40), done.
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/introduction/overview/2015/01/09/impatient-new-user.html
+++ b/blog/introduction/overview/2015/01/09/impatient-new-user.html
@@ -9,6 +9,7 @@
   <title>An Impatient New User's Introduction to API Management with JBoss apiman 1.0 | apiman Open Source API Management</title>
   <meta name="description" content="Software application development models are evolutionary things. New technologies are always being createdand require new approaches. It’s frequently the cas...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -892,6 +900,69 @@ Resolving deltas: 100% (40/40), done.
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/micro-services/development/2015/11/12/micro-services.html
+++ b/blog/micro-services/development/2015/11/12/micro-services.html
@@ -9,6 +9,7 @@
   <title>The More You Know: apiman micro-services? | apiman Open Source API Management</title>
   <meta name="description" content="Let’s spend a little bit of time learning more about one of the newer ways youcan run apiman:  as a set of micro-services.Running apiman in this way has seve...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/micro-services/development/2015/11/12/micro-services.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -313,6 +321,69 @@ that you can do this yourself by overriding this:</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/microservices/conference/talk/2015/06/15/apiman-msa-day.html
+++ b/blog/microservices/conference/talk/2015/06/15/apiman-msa-day.html
@@ -9,6 +9,7 @@
   <title>Microservices Architecture Day Appearance | apiman Open Source API Management</title>
   <meta name="description" content="I had the pleasure of presenting on apiman at the recent Microservices Architecture Developer Day, with our colleague Kurt delivering a short demo of our sof...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/microservices/conference/talk/2015/06/15/apiman-msa-day.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -257,6 +265,69 @@
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/plugins/policies/development/maven/2015/03/06/custom-policies-redux.html
+++ b/blog/plugins/policies/development/maven/2015/03/06/custom-policies-redux.html
@@ -9,6 +9,7 @@
   <title>Customizing JBoss apiman Through Policy Plugins | apiman Open Source API Management</title>
   <meta name="description" content="This is the second in a series of articles exploring API management with JBoss apiman. The first articlewas a general introduction to apiman for impatient us...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/plugins/policies/development/maven/2015/03/06/custom-policies-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -485,6 +493,69 @@ Configuration files for the plugin are contained in the apiman directory. The pr
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/plugins/policies/development/maven/2015/03/06/custom-policies.html
+++ b/blog/plugins/policies/development/maven/2015/03/06/custom-policies.html
@@ -9,6 +9,7 @@
   <title>Customizing JBoss apiman Through Policy Plugins | apiman Open Source API Management</title>
   <meta name="description" content="This is the second in a series of articles exploring API management with JBoss apiman. The first articlewas a general introduction to apiman for impatient us...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -613,6 +621,69 @@ Configuration files for the plugin are contained in the apiman directory. The pr
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/policies/2015/08/17/limiting-policies-redux.html
+++ b/blog/policies/2015/08/17/limiting-policies-redux.html
@@ -9,6 +9,7 @@
   <title>apiman Limiting Policies | apiman Open Source API Management</title>
   <meta name="description" content="In this, the sixth article in the series on apiman, JBoss’ new API Management framework, we’ll examine how apiman enables you to govern access to managed API...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/policies/2015/08/17/limiting-policies-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -343,6 +351,69 @@
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/policies/2015/08/17/limiting-policies.html
+++ b/blog/policies/2015/08/17/limiting-policies.html
@@ -9,6 +9,7 @@
   <title>apiman Limiting Policies | apiman Open Source API Management</title>
   <meta name="description" content="In this, the sixth article in the series on apiman, JBoss’ new API Management framework, we’ll examine how apiman enables you to govern access to managed ser...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -471,6 +479,69 @@
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/policy/junit/testing/2015/05/09/policy-testing-redux.html
+++ b/blog/policy/junit/testing/2015/05/09/policy-testing-redux.html
@@ -9,6 +9,7 @@
   <title>A great way to test your custom apiman policy! | apiman Open Source API Management</title>
   <meta name="description" content="If you have tried creating your own custom apiman policy, you may have had a little bit ofdifficulty creating useful junit tests for it.  Many policies requi...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -613,6 +621,69 @@ back end API for the test instead of the echo API!  :)</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/policy/junit/testing/2015/05/09/policy-testing.html
+++ b/blog/policy/junit/testing/2015/05/09/policy-testing.html
@@ -9,6 +9,7 @@
   <title>A great way to test your custom apiman policy! | apiman Open Source API Management</title>
   <meta name="description" content="If you have tried creating your own custom apiman policy, you may have had a little bit ofdifficulty creating useful junit tests for it.  Many policies requi...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -613,6 +621,69 @@ back end service for the test instead of the echo service!  :)</p>
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/rest/api/automation/2015/05/19/rest-api-redux.html
+++ b/blog/rest/api/automation/2015/05/19/rest-api-redux.html
@@ -9,6 +9,7 @@
   <title>The JBoss apiman API Manager REST API | apiman Open Source API Management</title>
   <meta name="description" content="In this, the third article in our series on apiman, JBoss’ new open source API Management framework, we’ll examine apiman’s API Manager REST API. apiman’s Ma...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/rest/api/automation/2015/05/19/rest-api-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -518,6 +526,69 @@ Return code = 200
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/rest/api/automation/2015/05/19/rest-api.html
+++ b/blog/rest/api/automation/2015/05/19/rest-api.html
@@ -9,6 +9,7 @@
   <title>The JBoss apiman API Manager REST services API | apiman Open Source API Management</title>
   <meta name="description" content="In this, the third article in our series on apiman, JBoss’ new open source API Management framework, we’ll examine apiman’s API Manager REST services API. ap...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -646,6 +654,69 @@ Return code = 200
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/security/2015/08/03/policy-endpoint-security-redux.html
+++ b/blog/security/2015/08/03/policy-endpoint-security-redux.html
@@ -9,6 +9,7 @@
   <title>apiman Policy and Endpoint Security | apiman Open Source API Management</title>
   <meta name="description" content="In this, the fifth article in the series on apiman, JBoss’ new API Management framework, we’ll examine how apiman enables you to provide security for your ma...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/security/2015/08/03/policy-endpoint-security-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -382,6 +390,69 @@
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/security/2015/08/03/policy-endpoint-security.html
+++ b/blog/security/2015/08/03/policy-endpoint-security.html
@@ -9,6 +9,7 @@
   <title>apiman Policy and Endpoint Security | apiman Open Source API Management</title>
   <meta name="description" content="In this, the fifth article in the series on apiman, JBoss’ new API Management framework, we’ll examine how apiman enables you to provide security for your ma...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -510,6 +518,69 @@
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/security/plugin/policy/cors/1.2.x/2016/01/22/cors-redux.html
+++ b/blog/security/plugin/policy/cors/1.2.x/2016/01/22/cors-redux.html
@@ -9,6 +9,7 @@
   <title>CORS? Of Course! | apiman Open Source API Management</title>
   <meta name="description" content="If you&#8217;re looking to define CORS policies in your API Management layer, then we have an official plugin that should be perfect for the job.For those un...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,23 +32,27 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="http://apiman.io/blog/security/plugin/policy/cors/1.2.x/2016/01/22/cors-redux.html">
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -638,6 +646,69 @@ When <code>Host</code> and <code>Origin</code> are equal, a request will automat
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/blog/security/plugin/policy/cors/2015/07/02/cors.html
+++ b/blog/security/plugin/policy/cors/2015/07/02/cors.html
@@ -9,6 +9,7 @@
   <title>CORS? Of Course! | apiman Open Source API Management</title>
   <meta name="description" content="If you&#8217;re looking to define CORS policies in your API Management layer, then we have an official plugin policy that should be perfect for the job.For t...">
 
+  <!-- CSS -->
   <link href="http://www.apiman.io/latest/resources/bootstrap-3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="http://www.apiman.io/latest/resources/patternfly-1.0.5/css/patternfly.min.css" rel="stylesheet">
   <link href="http://static.jboss.org/css/rhbar.css" media="screen" rel="stylesheet">
@@ -18,7 +19,10 @@
   <link href="/blog/css/highlight.css" rel="stylesheet">
   <link href="/blog/css/main.css" rel="stylesheet">
   <link href="/blog/css/coderay-asciidoctor.css" rel="stylesheet">
-  
+
+
+  <!-- Scripts -->
+
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>
@@ -28,18 +32,8 @@
   
   <script src="http://www.apiman.io/latest/resources/jquery-1.11.1/js/jquery.min.js"></script>
   <script src="http://www.apiman.io/latest/resources/bootstrap-3.3.0/js/bootstrap.min.js"></script>
-  <script>
-      $(document).ready(function() {
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-              ga('create', 'UA-56678850-1', 'auto');
-              ga('send', 'pageview');
-      });
-  </script>
-
+  <!-- Canonical URL -->
     
     <link rel="canonical" href="
               
@@ -173,6 +167,20 @@
     
 
   <link rel="alternate" type="application/rss+xml" title="apiman Blog | Open Source API Management" href="http://apiman.io/blog/feed.xml" />
+
+
+  <!-- Google Analytics -->
+  <script>
+    $(document).ready(function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-56678850-1', 'auto');
+      ga('send', 'pageview');
+    });
+  </script>
 </head>
 
   <body class="blog">
@@ -791,6 +799,69 @@ When <code>Host</code> and <code>Origin</code> are equal, a request will automat
         </div>
         <nav class="clearfix"></nav>
     </div>
+
+    <!-- Adobe Analytics -->
+    <script src="//www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | "; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman |  | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="//www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
 </footer>
 
       </div>

--- a/latest/api-manager-restdocs.html
+++ b/latest/api-manager-restdocs.html
@@ -154,5 +154,68 @@
         </footer>
     </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
+
   </body>
 </html>

--- a/latest/chat.html
+++ b/latest/chat.html
@@ -156,5 +156,68 @@
         </footer>
     </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
+
   </body>
 </html>

--- a/latest/contributors.html
+++ b/latest/contributors.html
@@ -175,5 +175,68 @@
         </footer>
     </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
+
   </body>
 </html>

--- a/latest/developer-guide.html
+++ b/latest/developer-guide.html
@@ -165,5 +165,68 @@
         </footer>
     </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
+
   </body>
 </html>

--- a/latest/disclosure.html
+++ b/latest/disclosure.html
@@ -182,5 +182,67 @@ possible. If you have any questions on contributing, join us on <a href="chat.ht
         </footer>
     </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
   </body>
 </html>

--- a/latest/download.html
+++ b/latest/download.html
@@ -399,5 +399,68 @@ docker run -it -p 8080:8080 -p 8443:8443 apiman/on-wildfly9:1.2.3.Final
         </footer>
     </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
+
   </body>
 </html>

--- a/latest/index.html
+++ b/latest/index.html
@@ -216,5 +216,67 @@
         </footer>
     </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
   </body>
 </html>

--- a/latest/installation-guide.html
+++ b/latest/installation-guide.html
@@ -165,5 +165,67 @@
         </footer>
     </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
   </body>
 </html>

--- a/latest/production-guide.html
+++ b/latest/production-guide.html
@@ -165,5 +165,68 @@
         </footer>
     </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
+
   </body>
 </html>

--- a/latest/roadmap.html
+++ b/latest/roadmap.html
@@ -431,6 +431,69 @@
             </div>
         </footer>
     </div>
+    </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
   </body>
 </html>

--- a/latest/tutorials.html
+++ b/latest/tutorials.html
@@ -186,5 +186,68 @@
         </footer>
     </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
+
   </body>
 </html>

--- a/latest/user-guide.html
+++ b/latest/user-guide.html
@@ -165,5 +165,68 @@
         </footer>
     </div>
 
+    <!-- Adobe Analytics -->
+    <script src="http://www.redhat.com/j/s_code.js" />
+    <script>
+        /**
+         * Adobe Analytics
+         *
+         * Variables reported to Adobe Analytics:
+         *  -pageName
+         *  -server
+         *  -channel
+         *  -first minor section
+         *  -second minor section (if available)
+         *  -third minor section (if available)
+         *  -full URL (domain + path + query string)
+         *  -base URL (domain + path)
+         *  -language
+         *  -country
+         *
+         */
+
+        /**
+         * Additional JS files to be loaded BEFORE adobe-analytics.js:
+         *
+         * - http://www.redhat.com/j/s_code.js
+         *
+         * Additional JS files to be loaded AFTER adobe-analytics.js
+         *
+         * - http://www.redhat.com/j/rh_omni_footer.js
+         */
+
+
+        (function() {
+
+            // Load the path name, without its initial /
+            var arr = location.pathname.substr(1, location.pathname.length).toLowerCase().split('/');
+            // If the path ends in index.html or whitespace, trim the array
+            if (arr[arr.length - 1] == "index.html" || arr[arr.length - 1] == "" ) {
+                arr.pop();
+            }
+
+            /*
+             * Assign values to Adobe Analytics properties
+             */
+
+            s.channel = "apiman | {{Channel}}"; // The channel is our top level classification
+            s.server = "apiman"; // The server is ???
+            s.pageName = "apiman | {{Channel}} | " + (arr[arr.length -1] || "homepage"); // pageName is apiman | <Channel> | {page_name}. {page_name} has index.html removed
+            s.prop2 = s.eVar22 = "en"; // prop2/eVar22 is the ISO 639-1 language code
+            s.prop4 = s.eVar23 = encodeURI(location.search); //prop4/eVar23 is the query string of the page
+
+            // Pad the array as needed, so we can shift away later
+            for (var i = arr.length; i < 3; i++) {
+                arr[i] = "";
+            }
+
+            s.prop14 = s.eVar27 = arr.shift(); // prop14/eVar27 is the first minor section (normally /{minor_section_1})
+            s.prop15 = s.eVar28 = arr.shift(); // prop15/eVar28 is the second minor section (normally /a/{minor_section_2})
+            s.prop16 = s.eVar29 = arr.shift(); // prop16/eVar29 is the third minor section (normally /a/b/{minor_section_3})
+            s.prop21 = s.eVar18 = encodeURI(location.hostname+location.pathname).toLowerCase(); // prop21/eVar18 is the URL, less any query strings or fragments
+        })();
+    </script>
+    <script src="http://www.redhat.com/assets/js/tracking/rh_omni_footer.js"/>
+
   </body>
 </html>


### PR DESCRIPTION
Added Adobe analytics tracking code to footer of all blog pages and static pages of the apiman website. Could not add to header as it caused all pages to be blank.

Also just added a `<!-- Google Analytics -->` comment or similar to blocks of code in the header for easier reading.

JIRA: https://issues.jboss.org/browse/APIMAN-1049

cc @EricWittmann 