### PR TITLE
pre-release-preps

### DIFF
--- a/latest/api-manager-restdocs.html
+++ b/latest/api-manager-restdocs.html
@@ -99,7 +99,10 @@
                         <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/development/Guide.html">Developer Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.htmll">Production Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.html">Production Guide</a>
+                    </li>
+                    <li class="menu-item">
+                        <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/migration/migrations.html">Migration Guide</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">

--- a/latest/api-manager-restdocs.html
+++ b/latest/api-manager-restdocs.html
@@ -86,20 +86,20 @@
                         <a href="tutorials.html">Tutorials &amp; Walkthroughs</a>
                     </li>
                     <li class="menu-item">
-                        <a href="crash-course.html">Crash Course!</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/crash-course/Guide.html">Crash Course!</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-installation-guide/">Installation Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/index.html">Installation Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-user-guide/">User Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/index.html">User Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="developer-guide.html">Developer Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/development/Guide.html">Developer Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-production-guide/">Production Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.htmll">Production Guide</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">

--- a/latest/contributors.html
+++ b/latest/contributors.html
@@ -78,20 +78,20 @@
                         <a href="tutorials.html">Tutorials &amp; Walkthroughs</a>
                     </li>
                     <li class="menu-item">
-                        <a href="crash-course.html">Crash Course!</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/crash-course/Guide.html">Crash Course!</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-installation-guide/">Installation Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/index.html">Installation Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-user-guide/">User Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/index.html">User Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="developer-guide.html">Developer Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/development/Guide.html">Developer Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-production-guide/">Production Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.htmll">Production Guide</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">

--- a/latest/crash-course.html
+++ b/latest/crash-course.html
@@ -96,20 +96,20 @@
                         <a href="tutorials.html">Tutorials &amp; Walkthroughs</a>
                     </li>
                     <li class="menu-item">
-                        <a href="crash-course.html">Crash Course!</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/crash-course/Guide.html">Crash Course!</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-installation-guide/">Installation Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/index.html">Installation Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-user-guide/">User Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/index.html">User Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="developer-guide.html">Developer Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/development/Guide.html">Developer Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-production-guide/">Production Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.htmll">Production Guide</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">

--- a/latest/developer-guide.html
+++ b/latest/developer-guide.html
@@ -96,20 +96,20 @@
                         <a href="tutorials.html">Tutorials &amp; Walkthroughs</a>
                     </li>
                     <li class="menu-item">
-                        <a href="crash-course.html">Crash Course!</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/crash-course/Guide.html">Crash Course!</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-installation-guide/">Installation Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/index.html">Installation Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-user-guide/">User Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/index.html">User Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="developer-guide.html">Developer Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/development/Guide.html">Developer Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-production-guide/">Production Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.htmll">Production Guide</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">

--- a/latest/disclosure.html
+++ b/latest/disclosure.html
@@ -78,20 +78,20 @@
                         <a href="tutorials.html">Tutorials &amp; Walkthroughs</a>
                     </li>
                     <li class="menu-item">
-                        <a href="crash-course.html">Crash Course!</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/crash-course/Guide.html">Crash Course!</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-installation-guide/">Installation Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/index.html">Installation Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-user-guide/">User Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/index.html">User Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="developer-guide.html">Developer Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/development/Guide.html">Developer Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-production-guide/">Production Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.htmll">Production Guide</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">

--- a/latest/download.html
+++ b/latest/download.html
@@ -78,20 +78,20 @@
                         <a href="tutorials.html">Tutorials &amp; Walkthroughs</a>
                     </li>
                     <li class="menu-item">
-                        <a href="crash-course.html">Crash Course!</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/crash-course/Guide.html">Crash Course!</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-installation-guide/">Installation Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/index.html">Installation Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-user-guide/">User Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/index.html">User Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="developer-guide.html">Developer Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/development/Guide.html">Developer Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-production-guide/">Production Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.htmll">Production Guide</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">

--- a/latest/index.html
+++ b/latest/index.html
@@ -81,20 +81,20 @@
                         <a href="tutorials.html">Tutorials &amp; Walkthroughs</a>
                     </li>
                     <li class="menu-item">
-                        <a href="crash-course.html">Crash Course!</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/crash-course/Guide.html">Crash Course!</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-installation-guide/">Installation Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/index.html">Installation Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-user-guide/">User Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/index.html">User Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="developer-guide.html">Developer Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/development/Guide.html">Developer Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-production-guide/">Production Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.htmll">Production Guide</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">

--- a/latest/production-guide.html
+++ b/latest/production-guide.html
@@ -96,20 +96,20 @@
                         <a href="tutorials.html">Tutorials &amp; Walkthroughs</a>
                     </li>
                     <li class="menu-item">
-                        <a href="crash-course.html">Crash Course!</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/crash-course/Guide.html">Crash Course!</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-installation-guide/">Installation Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/index.html">Installation Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-user-guide/">User Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/index.html">User Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="developer-guide.html">Developer Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/development/Guide.html">Developer Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-production-guide/">Production Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.htmll">Production Guide</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">

--- a/latest/roadmap.html
+++ b/latest/roadmap.html
@@ -89,20 +89,20 @@
                             <a href="tutorials.html">Tutorials &amp; Walkthroughs</a>
                         </li>
                         <li class="menu-item">
-                            <a href="crash-course.html">Crash Course!</a>
+                            <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/crash-course/Guide.html">Crash Course!</a>
                         </li>
                         <li class="divider"></li>
                         <li class="menu-item">
-                            <a href="https://apiman.gitbooks.io/apiman-installation-guide/">Installation Guide</a>
+                            <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/index.html">Installation Guide</a>
                         </li>
                         <li class="menu-item">
-                            <a href="https://apiman.gitbooks.io/apiman-user-guide/">User Guide</a>
+                            <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/index.html">User Guide</a>
                         </li>
                         <li class="menu-item">
-                            <a href="developer-guide.html">Developer Guide</a>
+                            <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/development/Guide.html">Developer Guide</a>
                         </li>
                         <li class="menu-item">
-                            <a href="https://apiman.gitbooks.io/apiman-production-guide/">Production Guide</a>
+                            <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.htmll">Production Guide</a>
                         </li>
                         <li class="divider"></li>
                         <li class="menu-item">

--- a/latest/tutorials.html
+++ b/latest/tutorials.html
@@ -78,20 +78,20 @@
                         <a href="tutorials.html">Tutorials &amp; Walkthroughs</a>
                     </li>
                     <li class="menu-item">
-                        <a href="crash-course.html">Crash Course!</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/crash-course/Guide.html">Crash Course!</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-installation-guide/">Installation Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/index.html">Installation Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-user-guide/">User Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/user-guide/2.1.0.Final/index.html">User Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="developer-guide.html">Developer Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/core/2.1.0.Final/development/Guide.html">Developer Guide</a>
                     </li>
                     <li class="menu-item">
-                        <a href="https://apiman.gitbooks.io/apiman-production-guide/">Production Guide</a>
+                        <a href="https://www.apiman.io/apiman-docs/installation-guide/2.1.0.Final/production.htmll">Production Guide</a>
                     </li>
                     <li class="divider"></li>
                     <li class="menu-item">


### PR DESCRIPTION
Add links to new antora docs. I think some pages are not in use anymore but should be fine anyways